### PR TITLE
Bug/emojis as chars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Jetbrains
+.idea/

--- a/README.md
+++ b/README.md
@@ -14,20 +14,20 @@ Create a Slack app for running a development version of Gratibot:
     - If you're developing in a shared workspace, consider a name like `${your_name}-bot`.
 This will help others to identify who owns the bot.
 3. Select the Slack workspace you'll run the bot in for development.
-4. Click the 'Create App' button.
+4. Click the *Create App* button.
 
 ##### Run Your Local Copy
 TODO: Update for k8s development.
 
 1. Give your app a very basic permission so we have the ability to install
 our app. We'll need to re-install the app later as we add new permission scopes.
-    1. On the sidebar, select the 'OAuth & Permission' tab, under 'Features'
-    2. On this tab, scroll to the 'Scopes'. Add the Bot Token Scope, `app_mentions:read`.
-    3. Go to the tab 'Install App' under 'Features'. Click through the required
+    1. On the sidebar, select the *OAuth & Permission* tab, under *Features*
+    2. On this tab, scroll to the *Scopes*. Add the Bot Token Scope, `app_mentions:read`.
+    3. Go to the tab *Install App* under *Settings*. Click through the required
 prompts to install the app.
-2. On the 'Basic Information' tab under 'Settings', find your App Credentials.
-Show the 'Signing Secret' value, and save it for later.
-3. On the 'Install App' tab under 'Settings' copy the 'Bot User OAuth Access Token'
+2. On the *Basic Information* tab under *Settings*, find your App Credentials.
+Show the *Signing Secret* value, and save it for later.
+3. On the *Install App* tab under *Settings* copy the *Bot User OAuth Access Token*
 value, and save it for later.
 4. In your cloned copy of the repo, create a file called `.env`, it should look
 something like:
@@ -48,9 +48,9 @@ be sure to note the hostname that ngrok generates as we'll need it later.
 
 1. Now that the bot is running, we can configure Slack to send specific
 notification to it, which will trigger bot actions. In the
-'Interactivity & Shortcuts' tab under 'Features' enable Interactivity and set
+*Interactivity & Shortcuts* tab under *Features* enable Interactivity and set
 the Request URL to `https://${NGROK_HOSTNAME}/api/messages`
-2. On the 'Event Subscriptions' tab under 'Features' enable Events, and set the
+2. On the *Event Subscriptions* tab under *Features* enable Events, and set the
 Request URL to `https://${NGROK_HOSTNAME}/api/messages`
 3. On the same tab, we'll need to subscribe to bot events. Existing Gratibot
 functionality requires the following:
@@ -60,19 +60,20 @@ functionality requires the following:
     - `message.im`
     - `message.mpim`
     - `reaction_added`
+    
 If you're developing new functionality, you may need additional event
 subscriptions.
-4. Return to the 'OAuth & Permissions' tab, as we'll need to add a few more
+4. Return to the *OAuth & Permissions* tab, as we'll need to add a few more
 scopes to the app. Slack with automatically add scopes required for the event
 subscriptions we already set. In addition to those, we'll also need to add the
 following:
     - `chat:write`
     - `users:read`
+    
 Once again, if you're developing new functionality, you may need additional
 scopes to be granted.
 5. Reinstall the app by clicking the button at the top of this tab. You'll need
 to reinstall the app any time you request additional scopes.
-
 
 With all of these steps complete, your bot should be running in the Slack
 workspace you chose to develop for. You should now be ready to test your bot,

--- a/config.js
+++ b/config.js
@@ -4,7 +4,6 @@ config.mongo_url = process.env.MONGO_URL || 'mongodb://mongodb:27017/gratibot';
 
 config.logLevel = process.env.LOG_LEVEL || 'info';
 
-config.emoji = process.env.EMOJI || ':fistbump:';
 config.reactionEmoji = 'nail_care'
 config.maximum = 5;
 config.minimumMessageLength = 20;

--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ config.mongo_url = process.env.MONGO_URL || 'mongodb://mongodb:27017/gratibot';
 
 config.logLevel = process.env.LOG_LEVEL || 'info';
 
+config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ':fistbump:';
 config.reactionEmoji = 'nail_care'
 config.maximum = 5;
 config.minimumMessageLength = 20;

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     environment:
       - SIGNING_SECRET
       - BOT_USER_OAUTH_ACCESS_TOKEN
-      - EMOJI
+      - RECOGNIZE_EMOJI
       - MONGO_URL=mongodb://mongodb:27017/gratibot
   mongodb:
     ports:

--- a/features/deduct.js
+++ b/features/deduct.js
@@ -1,4 +1,3 @@
-const { emoji } = require('../config')
 const deduction = require('../service/deduction')
 const balance = require('../service/balance')
 const winston = require('../winston')

--- a/features/help.js
+++ b/features/help.js
@@ -1,4 +1,4 @@
-const { emoji, maximum } = require('../config')
+const { recognizeEmoji, maximum } = require('../config')
 const winston = require('../winston')
 
 module.exports = function(controller) {
@@ -27,21 +27,21 @@ You can give up to ${maximum} recognitions per day.
 
 First, make sure I have been invited to the channel you want to recognize \
 someone in. Then, write a brief message describing what someone did, \
-\`@mention\` them and include the ${emoji} emoji...I'll take it from there!
+\`@mention\` them and include the ${recognizeEmoji} emoji...I'll take it from there!
 
-> Thanks @alice for helping me fix my pom.xml ${emoji}
+> Thanks @alice for helping me fix my pom.xml ${recognizeEmoji}
 
 Recognize multiple people at once!
 
-> @bob and @alice crushed that showcase! ${emoji}
+> @bob and @alice crushed that showcase! ${recognizeEmoji}
 
 Use \`#tags\` to call out specific Liatrio values!
 
-> I love the #energy in your Terraform demo @alice! ${emoji}
+> I love the #energy in your Terraform demo @alice! ${recognizeEmoji}
 
 The more emojis you add, the more recognition they get!
 
-> @alice just pushed the cleanest code I've ever seen! ${emoji} ${emoji} ${emoji}
+> @alice just pushed the cleanest code I've ever seen! ${recognizeEmoji} ${recognizeEmoji} ${recognizeEmoji}
 
 
 
@@ -51,7 +51,7 @@ The more emojis you add, the more recognition they get!
 Send me a direct message with 'balance' and I'll let you know how many \
 recognitions you have left to give and how many you have received.
 
-> You have received 0 ${emoji} and you have ${maximum} ${emoji} remaining to \
+> You have received 0 ${recognizeEmoji} and you have ${maximum} ${recognizeEmoji} remaining to \
 give away today
 
 

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -1,11 +1,11 @@
-const { emoji, maximum, minimumMessageLength, usersExemptFromMaximum, reactionEmoji } = require('../config')
+const { maximum, minimumMessageLength, usersExemptFromMaximum, reactionEmoji } = require('../config')
 const recognition = require('../service/recognition')
 const balance = require('../service/balance')
 const winston = require('../winston')
 
 const userRegex = /<@([a-zA-Z0-9]+)>/g;
 const tagRegex = /#(\S+)/g;
-const emojiRegex = new RegExp(emoji, 'g');
+const emojiRegex = /:(\S+):/g;
 
 module.exports = function(controller) {
     controller.hears(emoji , ['direct_message', 'direct_mention', 'mention', 'message'], async (bot, message) => {

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -1,4 +1,4 @@
-const { recognizeEmoji, minimumMessageLength, usersExemptFromMaximum, reactionEmoji } = require('../config')
+const { recognizeEmoji, maximum, minimumMessageLength, usersExemptFromMaximum, reactionEmoji } = require('../config')
 const recognition = require('../service/recognition')
 const balance = require('../service/balance')
 const winston = require('../winston')


### PR DESCRIPTION
As currently implemented, emoji names are counted as part of the total message length. This allows users to potentially circumvent the requirement for a detailed recognition descriptions. Consider the following example:

> :fistbump: :longenoughmessagetosatisfygratibotchecking: @some_user

This message would be considered verbose enough to pass as a valid recognition. The proposed changes simply remove _all_ emojis characters from the `trimmedMessage` variable to ensure that a full recognition description is provided.