### PR TITLE
Refaction Recognize Feature

### DIFF
--- a/features/recognize.js
+++ b/features/recognize.js
@@ -7,7 +7,7 @@ const {
 } = require("../config");
 const recognition = require("../service/recognition");
 const balance = require("../service/balance");
-// const winston = require("../winston");
+const winston = require("../winston");
 
 const userRegex = /<@([a-zA-Z0-9]+)>/g;
 const tagRegex = /#(\S+)/g;
@@ -18,45 +18,34 @@ module.exports = function (controller) {
   controller.hears(
     recognizeEmoji,
     ["direct_message", "direct_mention", "mention", "message"],
-    async (bot, message) => {
-      const userInfo = await userDetails(bot, message, message.user);
-      if (!userInfo) {
-        // TODO Error handling
-        return;
-      }
-
-      const errors = await checkForRecognitionErrors(message, userInfo);
-      if (errors) {
-        await bot.replyEphemeral(
-          message,
-          [
-            `Sending ${recognizeEmoji} failed with the following error(s):`,
-            errors,
-          ].join("\n")
-        );
-        return;
-      }
-
-      await sendRecognition(message, userInfo);
-      const gratitudeRemaining = await balance.dailyGratitudeRemaining(
-        userInfo.giver.id,
-        userInfo.giver.tz
-      );
-
-      await Promise.all([
-        sendNotificationToReceivers(bot, message, userInfo),
-        bot.replyEphemeral(
-          message,
-          `Your ${recognizeEmoji} has been sent. You have ${gratitudeRemaining} left to give today.`
-        ),
-      ]);
-    }
+    respondToRecognitionMessage
   );
 
-  controller.on("reaction_added", testFunction);
+  controller.on("reaction_added", respondToRecognitionReaction);
 };
 
-async function testFunction(bot, message) {
+async function respondToRecognitionMessage(bot, message) {
+  winston.info(`Heard reference to ${recognizeEmoji}`, {
+    callingUser: message.user,
+    slackMessage: message.text,
+  });
+
+  let userInfo;
+  try {
+    userInfo = await userDetails(bot, message.text, message.user);
+  } catch (err) {
+    //TODO Error handing
+  }
+
+  const recognitionInfo = {
+    text: message.text,
+    channel: message.channel,
+  };
+
+  await validateAndSendRecognition(bot, message, recognitionInfo, userInfo);
+}
+
+async function respondToRecognitionReaction(bot, message) {
   if (
     !message.reaction.includes(reactionEmoji) ||
     message.item.type !== "message"
@@ -64,22 +53,67 @@ async function testFunction(bot, message) {
     return;
   }
 
-  let originalMessage = await bot.api.conversations.history({
-    channel: message.item.channel,
-    latest: message.item.ts,
-    limit: 1,
-    inclusive: true,
+  winston.info(`Saw a reaction containing ${reactionEmoji}`, {
+    callingUser: message.user,
+    reactionEmoji: message.reaction,
   });
-  originalMessage = originalMessage.messages[0];
-  originalMessage.channel = message.channel;
 
-  const userInfo = await userDetails(bot, originalMessage, message.user);
-  if (!userInfo) {
-    // TODO Error handling
-    return;
+  const messageReactedTo = (
+    await bot.api.conversations.history({
+      channel: message.item.channel,
+      latest: message.item.ts,
+      limit: 1,
+      inclusive: true,
+    })
+  ).messages[0];
+
+  let userInfo;
+  try {
+    userInfo = await userDetails(bot, messageReactedTo.text, message.user);
+  } catch (err) {
+    //TODO Error handing
   }
+  const recognitionInfo = {
+    text: messageReactedTo.text,
+    channel: message.channel,
+  };
 
-  const errors = await checkForRecognitionErrors(originalMessage, userInfo);
+  await validateAndSendRecognition(bot, message, recognitionInfo, userInfo);
+}
+
+async function userDetails(bot, messageText, giver) {
+  const userStrings = messageText.match(userRegex) || [];
+  const userIds = userStrings.map((user) => user.slice(2, -1));
+
+  const userInfo = {
+    giver: await singleUserDetails(bot, giver),
+    receivers: await Promise.all(
+      userIds.map(async (receiver) => singleUserDetails(bot, receiver))
+    ),
+  };
+
+  return userInfo;
+}
+
+async function singleUserDetails(bot, userId) {
+  const singleUserInfo = await bot.api.users.info({ user: userId });
+  if (singleUserInfo.ok) {
+    return singleUserInfo.user;
+  }
+  // TODO Create a better type for this error (Is currently string)
+  throw singleUserInfo.error;
+}
+
+async function validateAndSendRecognition(
+  bot,
+  message,
+  recognitionInfo,
+  userInfo
+) {
+  const errors = await checkForRecognitionErrors(
+    recognitionInfo.text,
+    userInfo
+  );
   if (errors) {
     await bot.replyEphemeral(
       message,
@@ -91,14 +125,15 @@ async function testFunction(bot, message) {
     return;
   }
 
-  await sendRecognition(originalMessage, userInfo);
+  await sendRecognition(recognitionInfo, userInfo);
+
   const gratitudeRemaining = await balance.dailyGratitudeRemaining(
     userInfo.giver.id,
     userInfo.giver.tz
   );
 
-  await Promise.all([
-    sendNotificationToReceivers(bot, originalMessage, userInfo),
+  return Promise.all([
+    sendNotificationToReceivers(bot, recognitionInfo, userInfo),
     bot.replyEphemeral(
       message,
       `Your ${recognizeEmoji} has been sent. You have ${gratitudeRemaining} left to give today.`
@@ -106,49 +141,8 @@ async function testFunction(bot, message) {
   ]);
 }
 
-async function userDetails(bot, message, giver) {
-  const userStrings = message.text.match(userRegex) || [];
-  const userIds = userStrings.map((user) => user.slice(2, -1));
-  const userInfo = {
-    giver: await bot.api.users.info({ user: giver }),
-    receivers: await Promise.all(
-      userIds.map(async (user) => bot.api.users.info({ user: user }))
-    ),
-  };
-
-  return parseUserDetailsRequest(userInfo);
-}
-
-// TODO clean this up. Maybe check for errors after each API call?
-function parseUserDetailsRequest(userInfo) {
-  let infoRequestIsOk = true;
-  /*
-  if (!userInfo.giver.ok) {
-    winston.error("User info request failed", {
-      user: message.user,
-      error: userInfo.giver.error,
-    });
-    infoRequestIsOk = false;
-  }
-  */
-  userInfo.giver = userInfo.giver.user;
-  for (let i = 0; i < userInfo.receivers.length; i++) {
-    /*
-    if (!userInfo.receivers[i].ok) {
-      winston.error("User info request failed", {
-        user: userIds[i],
-        error: userInfo.receivers[i].error,
-      });
-      infoRequestIsOk = false;
-    }
-    */
-    userInfo.receivers[i] = userInfo.receivers[i].user;
-  }
-  return infoRequestIsOk ? userInfo : null;
-}
-
-async function checkForRecognitionErrors(message, userInfo) {
-  const trimmedMessage = message.text
+async function checkForRecognitionErrors(messageText, userInfo) {
+  const trimmedMessage = messageText
     .replace(userRegex, "")
     .replace(generalEmojiRegex, "");
 
@@ -170,7 +164,7 @@ async function checkForRecognitionErrors(message, userInfo) {
     trimmedMessage.length < minimumMessageLength
       ? `- Your message must be at least ${minimumMessageLength} characters`
       : "",
-    !(await isRecognitionWithinSpendingLimits(message, userInfo))
+    !(await isRecognitionWithinSpendingLimits(messageText, userInfo))
       ? `- A maximum of ${maximum} ${recognizeEmoji} can be sent per day`
       : "",
   ]
@@ -178,11 +172,11 @@ async function checkForRecognitionErrors(message, userInfo) {
     .join("\n");
 }
 
-async function isRecognitionWithinSpendingLimits(message, userInfo) {
+async function isRecognitionWithinSpendingLimits(messageText, userInfo) {
   if (usersExemptFromMaximum.includes(userInfo.giver.id)) {
     return true;
   }
-  const emojiInMessage = (message.text.match(recognizeEmojiRegex) || []).length;
+  const emojiInMessage = (messageText.match(recognizeEmojiRegex) || []).length;
   const recognitionGivenToday = await balance.dailyGratitudeRemaining(
     userInfo.giver.id,
     userInfo.giver.tz
@@ -191,9 +185,13 @@ async function isRecognitionWithinSpendingLimits(message, userInfo) {
   return recognitionGivenToday + recognitionInMessage <= maximum;
 }
 
-async function sendRecognition(message, userInfo) {
-  const tags = (message.text.match(tagRegex) || []).map((tag) => tag.slice(1));
-  const emojiCount = (message.text.match(recognizeEmojiRegex) || []).length;
+// TODO Can we add a 'count' field to the recognition?
+async function sendRecognition(recognitionInfo, userInfo) {
+  const tags = (recognitionInfo.text.match(tagRegex) || []).map((tag) =>
+    tag.slice(1)
+  );
+  const emojiCount = (recognitionInfo.text.match(recognizeEmojiRegex) || [])
+    .length;
   let results = [];
   for (let i = 0; i < userInfo.receivers.length; i++) {
     for (let j = 0; j < emojiCount; j++) {
@@ -201,8 +199,8 @@ async function sendRecognition(message, userInfo) {
         recognition.giveRecognition(
           userInfo.giver.id,
           userInfo.receivers[i].id,
-          message.text,
-          message.channel,
+          recognitionInfo.text,
+          recognitionInfo.channel,
           tags
         )
       );
@@ -211,7 +209,7 @@ async function sendRecognition(message, userInfo) {
   return Promise.all(results);
 }
 
-async function sendNotificationToReceivers(bot, message, userInfo) {
+async function sendNotificationToReceivers(bot, recognitionInfo, userInfo) {
   let results = [];
   for (let i = 0; i < userInfo.receivers.length; i++) {
     const numberRecieved = await recognition.countRecognitionsReceived(
@@ -219,7 +217,7 @@ async function sendNotificationToReceivers(bot, message, userInfo) {
     );
     results.push(
       bot.say({
-        text: `You just got recognized by <@${userInfo.giver.id}> in <#${message.channel}> and your new balance is \`${numberRecieved}\`\n>>>${message.text}`,
+        text: `You just got recognized by <@${userInfo.giver.id}> in <#${recognitionInfo.channel}> and your new balance is \`${numberRecieved}\`\n>>>${recognitionInfo.text}`,
         channel: userInfo.receivers[i].id,
       })
     );

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -34,9 +34,19 @@ async function respondToRecognitionMessage(bot, message) {
   try {
     userInfo = await userDetails(bot, message.text, message.user);
   } catch (err) {
-    //TODO Error handing
+    winston.error("Slack API returned error from users.info", {
+      callingUser: message.user,
+      slackMessage: message.text,
+      APIResponse: err,
+    });
+    await bot.replyEphemeral(
+      message,
+      `Something went wrong while sending recognition. When retreiving user information from Slack, the API responded with the following error: \n ${JSON.stringify(
+        err
+      )} \n Recognition has not been sent.`
+    );
+    return;
   }
-
 
   const recognitionInfo = {
     text: message.text,
@@ -72,7 +82,16 @@ async function respondToRecognitionReaction(bot, message) {
   try {
     userInfo = await userDetails(bot, messageReactedTo.text, message.user);
   } catch (err) {
-    //TODO Error handing
+    winston.error("Slack API returned error from users.info", {
+      callingUser: message.user,
+      slackMessage: message.text,
+      APIResponse: err,
+    });
+    await bot.replyEphemeral(
+      message,
+      `Something went wrong while sending recognition. When retreiving user information from Slack, the API responded with the following error: \n ${err} \n Recognition has not been sent.`
+    );
+    return;
   }
   const recognitionInfo = {
     text: messageReactedTo.text,
@@ -101,8 +120,7 @@ async function singleUserDetails(bot, userId) {
   if (singleUserInfo.ok) {
     return singleUserInfo.user;
   }
-  // TODO Create a better type for this error (Is currently string)
-  throw singleUserInfo.error;
+  throw singleUserInfo;
 }
 
 async function validateAndSendRecognition(

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -37,6 +37,7 @@ async function respondToRecognitionMessage(bot, message) {
     //TODO Error handing
   }
 
+
   const recognitionInfo = {
     text: message.text,
     channel: message.channel,
@@ -177,12 +178,12 @@ async function isRecognitionWithinSpendingLimits(messageText, userInfo) {
     return true;
   }
   const emojiInMessage = (messageText.match(recognizeEmojiRegex) || []).length;
-  const recognitionGivenToday = await balance.dailyGratitudeRemaining(
+  const dailyGratitudeRemaining = await balance.dailyGratitudeRemaining(
     userInfo.giver.id,
     userInfo.giver.tz
   );
   const recognitionInMessage = userInfo.receivers.length * emojiInMessage;
-  return recognitionGivenToday + recognitionInMessage <= maximum;
+  return dailyGratitudeRemaining >= recognitionInMessage;
 }
 
 // TODO Can we add a 'count' field to the recognition?

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -1,34 +1,62 @@
 const sinon = require("sinon");
 const suppressLogs = require("mocha-suppress-logs");
 const expect = require("chai").expect;
-const rewire = require("rewire");
 
 const MockController = require("../mocks/controller");
 
-const recognizeFeature = rewire("../../features/recognize");
+const recognizeFeature = require('../../features/recognize');
+const recognition = require('../../service/recognition');
+const balance = require('../../service/balance');
 
 describe("features/recognize", () => {
+  let controller;
 
-  describe("#checkForRecognitionErrors()", () => {
-    it("should return an empty array when there are no errors", async () => {
-      const messageText = ":fistbump: <@AAA1A1AA1> Test Test Test Test Test";
-      const userInfo = {
-        giver: {
-          id: "BBB2B2BB2",
-          is_bot: false,
-          is_restricted: false,
-        },
-        receivers: [{
-          id: "AAA1A1AA1",
-          is_bot: false,
-          is_restricted:false,
-        }],
-      };
-      const revert = recognizeFeature.__set__("isRecognitionWithinSpendingLimits", () => true);
-      const result = await recognizeFeature.__get__("checkForRecognitionErrors")(messageText, userInfo);
-      revert()
-      expect(result).to.equal("");
+  beforeEach(async () => {
+    controller = new MockController({});
+    await recognizeFeature(controller);
+  })
 
-    });
-  });
+  it("should update database on valid recognition", async () => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    controller.bot.api.users.info = sinon
+      .stub()
+      .onFirstCall()
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "AAA1A1AA1",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        }
+      )
+      .onSecondCall()
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "BBB2B2BB2",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        }
+      )
+
+    const reply = await controller.userInput(
+      {
+        text: ":fistbump: <@BBB2B2BB2> Test Test Test Test Test",
+        user: "AAA1A1AA1",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.true;
+
+  })
 });

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -1,12 +1,11 @@
 const sinon = require("sinon");
-const suppressLogs = require("mocha-suppress-logs");
 const expect = require("chai").expect;
 
 const MockController = require("../mocks/controller");
 
-const recognizeFeature = require('../../features/recognize');
-const recognition = require('../../service/recognition');
-const balance = require('../../service/balance');
+const recognizeFeature = require("../../features/recognize");
+const recognition = require("../../service/recognition");
+const balance = require("../../service/balance");
 
 describe("features/recognize", () => {
   let controller;
@@ -14,205 +13,326 @@ describe("features/recognize", () => {
   beforeEach(async () => {
     controller = new MockController({});
 
-
     controller.bot.api.users.info
-      .withArgs({ user:"Giver" })
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "Giver",
-            tz: "America/Los_Angeles",
-            is_bot: false,
-            is_restricted: false,
-          },
-        }
-      )
+      .withArgs({ user: "Giver" })
+      .resolves({
+        ok: true,
+        user: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+      })
       .withArgs({ user: "Receiver" })
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "Receiver",
-            tz: "America/Los_Angeles",
-            is_bot: false,
-            is_restricted: false,
-          },
-        }
-      )
+      .resolves({
+        ok: true,
+        user: {
+          id: "Receiver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+      })
       .withArgs({ user: "BotUser" })
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "BotUser",
-            tz: "America/Los_Angeles",
-            is_bot: true,
-            is_restricted: false,
-          },
-        }
-      )
+      .resolves({
+        ok: true,
+        user: {
+          id: "BotUser",
+          tz: "America/Los_Angeles",
+          is_bot: true,
+          is_restricted: false,
+        },
+      })
       .withArgs({ user: "GuestUser" })
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "GuestUser",
-            tz: "America/Los_Angeles",
-            is_bot: false,
-            is_restricted: true,
-          },
-        }
-      );
+      .resolves({
+        ok: true,
+        user: {
+          id: "GuestUser",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: true,
+        },
+      })
+      .withArgs({ user: "NotARealUser" })
+      .resolves({
+        ok: false,
+        error: "user_not_found",
+      });
 
     await recognizeFeature(controller);
-  })
+  });
 
   afterEach(() => {
     sinon.restore();
   });
 
-  it("should update database on valid recognition", async () => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+  describe("a recognition message", () => {
+    it("should update database on valid recognition", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Receiver> Test Test Test Test Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.true;
-  })
+      expect(giveRecognition.called).to.be.true;
+    });
 
-  it("shouldn't update database when there are no receivers", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("should parse out supplied message tags", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
+        text: ":fistbump: <@Receiver> Test Test Test Test #Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      });
+
+      expect(giveRecognition.args[0][4]).to.deep.equal(["Test"]);
+    });
+
+    it("should handle Slack API errors", async () => {
+      sinon.stub(recognition, "giveRecognition").resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      await controller.userInput({
+        text: ":fistbump: <@NotARealUser> Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      });
+
+      // TODO: Test something
+    });
+
+    /*
+     * TODO: Need to figure out the correct way to mock config
+    it("should allow exempt users to give recognition over the maximum", async () => {
+      const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+      sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+      sinon.stub(balance, 'dailyGratitudeRemaining').resolves(0);
+      sinon.stub(config, 'usersExemptFromMaximum').value("Test");
+
+      await controller.userInput(
+        {
+          text: ":fistbump: <@Receiver> Test Test Test Test Test",
+          user: "Giver",
+          channel: "SomeChannel",
+        }
+      )
+
+      expect(giveRecognition.called).to.be.true;
+    })
+    */
+    it("shouldn't update database when there are no receivers", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      await controller.userInput({
         text: ":fistbump: Test Test Test Test Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when giver matches a receiver", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when giver matches a receiver", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Giver> Test Test Test Test Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when giver is a bot user", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when giver is a bot user", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Receiver> Test Test Test Test Test",
         user: "BotUser",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when giver is a guest user", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when giver is a guest user", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Receiver> Test Test Test Test Test",
         user: "GuestUser",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when receiver is a bot user", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when receiver is a bot user", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@BotUser> Test Test Test Test Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when receiver is a guest user", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when receiver is a guest user", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@GuestUser> Test Test Test Test Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when message is too short", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+    it("shouldn't update database when message is too short", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Receiver> Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
 
-  it("shouldn't update database when giver has no recognition to spend", async() => {
-    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(0);
+    it("shouldn't update database when giver has no recognition to spend", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(0);
 
-    await controller.userInput(
-      {
+      await controller.userInput({
         text: ":fistbump: <@Receiver> Test",
         user: "Giver",
         channel: "SomeChannel",
-      }
-    )
+      });
 
-    expect(giveRecognition.called).to.be.false;
-  })
+      expect(giveRecognition.called).to.be.false;
+    });
+  });
+
+  describe("a recognition reaction", () => {
+    it("should update database on valid recognition", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      controller.bot.api.conversations.history.resolves({
+        messages: [{ text: ":fistbump: <@Receiver> Test Test Test Test Test" }],
+      });
+
+      await controller.event("reaction_added", {
+        reaction: ":nail_care:",
+        user: "Giver",
+        item: {
+          type: "message",
+          channel: "SomeChannel",
+          ts: "1",
+        },
+      });
+
+      expect(giveRecognition.called).to.be.true;
+    });
+
+    it("should handle Slack API errors", async () => {
+      sinon.stub(recognition, "giveRecognition").resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      controller.bot.api.conversations.history.resolves({
+        messages: [
+          { text: ":fistbump: <@NotARealUser> Test Test Test Test Test" },
+        ],
+      });
+
+      await controller.event("reaction_added", {
+        reaction: ":nail_care:",
+        user: "Giver",
+        item: {
+          type: "message",
+          channel: "SomeChannel",
+          ts: "1",
+        },
+      });
+
+      // TODO: Test something
+    });
+
+    it("shouldn't update database when the the wrong reaction emoji is used", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      controller.bot.api.conversations.history.resolves({
+        messages: [{ text: ":fistbump: <@Receiver> Test Test Test Test Test" }],
+      });
+
+      await controller.event("reaction_added", {
+        reaction: ":any_wrong_emoji:",
+        user: "Giver",
+        item: {
+          type: "message",
+          channel: "SomeChannel",
+          ts: "1",
+        },
+      });
+
+      expect(giveRecognition.called).to.be.false;
+    });
+  });
 });

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -6,6 +6,7 @@ const MockController = require("../mocks/controller");
 const recognizeFeature = require("../../features/recognize");
 const recognition = require("../../service/recognition");
 const balance = require("../../service/balance");
+const config = require("../../config");
 
 describe("features/recognize", () => {
   let controller;
@@ -101,7 +102,9 @@ describe("features/recognize", () => {
     });
 
     it("should handle Slack API errors", async () => {
-      sinon.stub(recognition, "giveRecognition").resolves("");
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
@@ -111,28 +114,26 @@ describe("features/recognize", () => {
         channel: "SomeChannel",
       });
 
-      // TODO: Test something
+      expect(giveRecognition.called).to.be.false;
     });
 
-    /*
-     * TODO: Need to figure out the correct way to mock config
     it("should allow exempt users to give recognition over the maximum", async () => {
-      const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
-      sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
-      sinon.stub(balance, 'dailyGratitudeRemaining').resolves(0);
-      sinon.stub(config, 'usersExemptFromMaximum').value("Test");
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(0);
+      sinon.stub(config, "usersExemptFromMaximum").value("Giver");
 
-      await controller.userInput(
-        {
-          text: ":fistbump: <@Receiver> Test Test Test Test Test",
-          user: "Giver",
-          channel: "SomeChannel",
-        }
-      )
+      await controller.userInput({
+        text: ":fistbump: <@Receiver> Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      });
 
       expect(giveRecognition.called).to.be.true;
-    })
-    */
+    });
+
     it("shouldn't update database when there are no receivers", async () => {
       const giveRecognition = sinon
         .stub(recognition, "giveRecognition")
@@ -288,7 +289,9 @@ describe("features/recognize", () => {
     });
 
     it("should handle Slack API errors", async () => {
-      sinon.stub(recognition, "giveRecognition").resolves("");
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
@@ -308,10 +311,10 @@ describe("features/recognize", () => {
         },
       });
 
-      // TODO: Test something
+      expect(giveRecognition.called).to.be.false;
     });
 
-    it("shouldn't update database when the the wrong reaction emoji is used", async () => {
+    it("shouldn't update database when the wrong reaction emoji is used", async () => {
       const giveRecognition = sinon
         .stub(recognition, "giveRecognition")
         .resolves("");

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -13,50 +13,206 @@ describe("features/recognize", () => {
 
   beforeEach(async () => {
     controller = new MockController({});
+
+
+    controller.bot.api.users.info
+      .withArgs({ user:"Giver" })
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "Giver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        }
+      )
+      .withArgs({ user: "Receiver" })
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        }
+      )
+      .withArgs({ user: "BotUser" })
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "BotUser",
+            tz: "America/Los_Angeles",
+            is_bot: true,
+            is_restricted: false,
+          },
+        }
+      )
+      .withArgs({ user: "GuestUser" })
+      .resolves(
+        {
+          ok: true,
+          user: {
+            id: "GuestUser",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: true,
+          },
+        }
+      );
+
     await recognizeFeature(controller);
   })
+
+  afterEach(() => {
+    sinon.restore();
+  });
 
   it("should update database on valid recognition", async () => {
     const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
     sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
     sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
 
-    controller.bot.api.users.info = sinon
-      .stub()
-      .onFirstCall()
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "AAA1A1AA1",
-            tz: "America/Los_Angeles",
-            is_bot: false,
-            is_restricted: false,
-          },
-        }
-      )
-      .onSecondCall()
-      .resolves(
-        {
-          ok: true,
-          user: {
-            id: "BBB2B2BB2",
-            tz: "America/Los_Angeles",
-            is_bot: false,
-            is_restricted: false,
-          },
-        }
-      )
-
-    const reply = await controller.userInput(
+    await controller.userInput(
       {
-        text: ":fistbump: <@BBB2B2BB2> Test Test Test Test Test",
-        user: "AAA1A1AA1",
+        text: ":fistbump: <@Receiver> Test Test Test Test Test",
+        user: "Giver",
         channel: "SomeChannel",
       }
     )
 
     expect(giveRecognition.called).to.be.true;
+  })
 
+  it("shouldn't update database when there are no receivers", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when giver matches a receiver", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@Giver> Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when giver is a bot user", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@Receiver> Test Test Test Test Test",
+        user: "BotUser",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when giver is a guest user", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@Receiver> Test Test Test Test Test",
+        user: "GuestUser",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when receiver is a bot user", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@BotUser> Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when receiver is a guest user", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@GuestUser> Test Test Test Test Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when message is too short", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(5);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@Receiver> Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
+  })
+
+  it("shouldn't update database when giver has no recognition to spend", async() => {
+    const giveRecognition = sinon.stub(recognition, 'giveRecognition').resolves("");
+    sinon.stub(recognition, 'countRecognitionsReceived').resolves(1);
+    sinon.stub(balance, 'dailyGratitudeRemaining').resolves(0);
+
+    await controller.userInput(
+      {
+        text: ":fistbump: <@Receiver> Test",
+        user: "Giver",
+        channel: "SomeChannel",
+      }
+    )
+
+    expect(giveRecognition.called).to.be.false;
   })
 });

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -1,0 +1,34 @@
+const sinon = require("sinon");
+const suppressLogs = require("mocha-suppress-logs");
+const expect = require("chai").expect;
+const rewire = require("rewire");
+
+const MockController = require("../mocks/controller");
+
+const recognizeFeature = rewire("../../features/recognize");
+
+describe("features/recognize", () => {
+
+  describe("#checkForRecognitionErrors()", () => {
+    it("should return an empty array when there are no errors", async () => {
+      const messageText = ":fistbump: <@AAA1A1AA1> Test Test Test Test Test";
+      const userInfo = {
+        giver: {
+          id: "BBB2B2BB2",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [{
+          id: "AAA1A1AA1",
+          is_bot: false,
+          is_restricted:false,
+        }],
+      };
+      const revert = recognizeFeature.__set__("isRecognitionWithinSpendingLimits", () => true);
+      const result = await recognizeFeature.__get__("checkForRecognitionErrors")(messageText, userInfo);
+      revert()
+      expect(result).to.equal("");
+
+    });
+  });
+});

--- a/test/mocks/bot.js
+++ b/test/mocks/bot.js
@@ -19,6 +19,9 @@ const mockBot = (controller) => ({
         return controller.update.call(controller, "main", message);
       },
     },
+    conversations: {
+      history: sinon.stub(),
+    },
     reactions: {
       add: function (reaction) {
         return new Promise((resolve) => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,6 @@
 const chai = require("chai");
 const chaiAsPromised = require("chai-as-promised");
+const winston = require("../winston");
+
+winston.silent = true;
 chai.use(chaiAsPromised);

--- a/winston.js
+++ b/winston.js
@@ -5,9 +5,7 @@ const loggingLevel = config.logLevel;
 const logger = winston.createLogger({
   level: loggingLevel,
   format: winston.format.json(),
-  transports: [
-    new winston.transports.Console(),
-  ],
+  transports: [new winston.transports.Console()],
 });
 
 module.exports = logger;

--- a/winston.js
+++ b/winston.js
@@ -2,18 +2,12 @@ const winston = require("winston");
 const config = require("./config");
 const loggingLevel = config.logLevel;
 
-winston.configure({
+const logger = winston.createLogger({
   level: loggingLevel,
+  format: winston.format.json(),
   transports: [
-    new winston.transports.Console({
-      format: winston.format.json(),
-    }),
-  ],
-  exceptionHandlers: [
-    new winston.transports.Console({
-      format: winston.format.json(),
-    }),
+    new winston.transports.Console(),
   ],
 });
 
-module.exports = winston;
+module.exports = logger;


### PR DESCRIPTION
# Recognize Feature Refactor

Restructures the recognize feature altering the way code is laid out to make recognition by message and by reaction emoji more DRY

### Recognize.js

- Renames some functions in Recognize.
- Scopes down some large parameter inputs from Botkit to make it more clear what variables are in use
- Restructures error handling for errors coming from Slack's API
- Adds some output to users for if Slack API errors occur.
- Adds basic logging output


### Testing

- Adds unit testing to recognize feature
- Tests most lines and statements, but a few minor branches are still not properly testing
- Adds stub to BotMock for Slacks conversations API

- Alters logging configuration to make it possible to temporarily silence logging
- Silences Winston logging during testing

