### PR TITLE
Fixes for embedded secrets and unique environment URLS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 tf/
+.env
 node_modules/
 README.md
 Dockerfile

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,7 +22,8 @@ jobs:
           ARM_TENANT_ID: "1b4a4fed-fed8-4823-a8a0-3d5cea83d122"
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          TF_VAR_gratibot_image: "docker.io/grantesparza/gratibot:v0.1.0"
+          TF_VAR_gratibot_image: "docker.io/grantesparza/gratibot:v0.1.1"
+          TF_VAR_environment: "nonprod"
           TF_VAR_signing_secret: ${{ secrets.SIGNING_SECRET }}
           TF_VAR_bot_user_token: ${{ secrets.BOT_USER_OAUTH_TOKEN }}
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -52,6 +52,7 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_gratibot_image: "docker.io/grantesparza/gratibot:v0.1.0"
+          TF_VAR_environment: "nonprod"
           TF_VAR_signing_secret: ${{ secrets.SIGNING_SECRET }}
           TF_VAR_bot_user_token: ${{ secrets.BOT_USER_OAUTH_TOKEN }}
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -26,7 +26,8 @@ jobs:
           ARM_TENANT_ID: "1b4a4fed-fed8-4823-a8a0-3d5cea83d122"
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          TF_VAR_gratibot_image: "docker.io/grantesparza/gratibot:v0.1.0"
+          TF_VAR_gratibot_image: "docker.io/grantesparza/gratibot:v0.1.1"
+          TF_VAR_environment: "nonprod"
           TF_VAR_signing_secret: ${{ secrets.SIGNING_SECRET }}
           TF_VAR_bot_user_token: ${{ secrets.BOT_USER_OAUTH_TOKEN }}
   plan:

--- a/tf/appservice.tf
+++ b/tf/appservice.tf
@@ -26,9 +26,9 @@ resource "azurerm_app_service" "gratibot_app_service" {
   }
 
   app_settings = {
-    "MONGO_URL"            = azurerm_cosmosdb_account.db_account.connection_strings[0]
-    "SIGNING_SECRET"       = var.signing_secret
+    "MONGO_URL"                   = azurerm_cosmosdb_account.db_account.connection_strings[0]
+    "SIGNING_SECRET"              = var.signing_secret
     "BOT_USER_OAUTH_ACCESS_TOKEN" = var.bot_user_token
-    "RECOGNIZE_EMOJI"      = ":oof:"
+    "RECOGNIZE_EMOJI"             = ":oof:"
   }
 }

--- a/tf/appservice.tf
+++ b/tf/appservice.tf
@@ -1,5 +1,5 @@
 resource "azurerm_app_service_plan" "gratibot_app_service_plan" {
-  name                = "gratibot-service-plan"
+  name                = "gratibot-${var.environment}-service-plan"
   location            = var.location
   resource_group_name = var.resource_group_name
   kind                = "Linux"
@@ -13,7 +13,7 @@ resource "azurerm_app_service_plan" "gratibot_app_service_plan" {
 }
 
 resource "azurerm_app_service" "gratibot_app_service" {
-  name                    = "gratibot-app-service"
+  name                    = "gratibot-${var.environment}-service"
   location                = var.location
   resource_group_name     = var.resource_group_name
   app_service_plan_id     = azurerm_app_service_plan.gratibot_app_service_plan.id
@@ -28,7 +28,7 @@ resource "azurerm_app_service" "gratibot_app_service" {
   app_settings = {
     "MONGO_URL"            = azurerm_cosmosdb_account.db_account.connection_strings[0]
     "SIGNING_SECRET"       = var.signing_secret
-    "BOT_USER_OAUTH_TOKEN" = var.bot_user_token
+    "BOT_USER_OAUTH_ACCESS_TOKEN" = var.bot_user_token
     "RECOGNIZE_EMOJI"      = ":oof:"
   }
 }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -15,6 +15,11 @@ variable "location" {
   type        = string
 }
 
+variable "environment" {
+  description = "Environment for Gratibot deployment(nonprod, prod)"
+  type        = string
+}
+
 variable "gratibot_image" {
   description = "Docker image to be used for Gratibot service"
   type        = string


### PR DESCRIPTION
Remove `.env` files from being included in build context. Also embed the target environment in App Service resources so that the generated URL is unique across environments.

> `BOT_USER_OAUTH_TOKEN` never would of worked...needs to be `BOT_USER_OAUTH_ACCESS_TOKEN`