### PR TITLE
Update default App Service resource usage

### DIFF
--- a/tf/appservice.tf
+++ b/tf/appservice.tf
@@ -6,9 +6,9 @@ resource "azurerm_app_service_plan" "gratibot_app_service_plan" {
   reserved            = true
 
   sku {
-    tier     = "PremiumV2"
-    size     = "P2v2"
-    capacity = "3"
+    tier     = var.instance_tier
+    size     = var.instance_size
+    capacity = var.instance_capacity
   }
 }
 

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -20,6 +20,25 @@ variable "environment" {
   type        = string
 }
 
+
+variable "instance_tier" {
+  description = "Service plan to use for App Serivce"
+  default     = "Basic"
+  type        = string
+}
+
+variable "instance_size" {
+  description = "Instance size to use for App Serivce"
+  default     = "B1"
+  type        = string
+}
+
+variable "instance_capacity" {
+  description = "Workers associated with App Service Plan"
+  default     = "1"
+  type        = string
+}
+
 variable "gratibot_image" {
   description = "Docker image to be used for Gratibot service"
   type        = string


### PR DESCRIPTION
Decrease App Service resource usage defaults. Wanted to also include serverless CosmosDB account but the provider does not support that [offer type](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/cosmosdb_account#offer_type) 