### PR TITLE
Fixes bugs in leaderboard feature that occur with larger datasets; Fi…

### DIFF
--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -88,7 +88,7 @@ async function createLeaderboardBlocks(timeRange) {
 function leaderboardHeader() {
   return {
     type: "section",
-    block_id: "leaderboard_header",
+    block_id: "leaderboardHeader",
     text: {
       type: "mrkdwn",
       text: "*Leaderboard*",
@@ -110,7 +110,7 @@ function topGivers(giverScores) {
 
   return {
     type: "section",
-    block_id: "recognizersTitle",
+    block_id: "topGivers",
     text: {
       type: "mrkdwn",
       text: markdown,
@@ -132,7 +132,7 @@ function topReceivers(receiverScores) {
 
   return {
     type: "section",
-    block_id: "recognizeesTitle",
+    block_id: "topReceivers",
     text: {
       type: "mrkdwn",
       text: markdown,

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -105,8 +105,8 @@ function leaderboardHeader() {
  *     section header and leaderboard entries.
  */
 function topGivers(giverScores) {
-  markdown = '*Top Givers*\n\n'
-  markdown += giverScores.map(leaderboardEntry).join('\n')
+  let markdown = "*Top Givers*\n\n";
+  markdown += giverScores.map(leaderboardEntry).join("\n");
 
   return {
     type: "section",
@@ -127,8 +127,8 @@ function topGivers(giverScores) {
  *     section header and leaderboard entries.
  */
 function topReceivers(receiverScores) {
-  markdown = '*Top Receivers*\n\n'
-  markdown += receiverScores.map(leaderboardEntry).join('\n')
+  let markdown = "*Top Receivers*\n\n";
+  markdown += receiverScores.map(leaderboardEntry).join("\n");
 
   return {
     type: "section",
@@ -224,7 +224,7 @@ function timeRangeButtons() {
  *     entry.
  */
 function leaderboardEntry(entry, index) {
-  return `<@${entry.userID}> *${rank[index]} - Score:* ${entry.score}`
+  return `<@${entry.userID}> *${rank[index]} - Score:* ${entry.score}`;
 }
 
 /* Data Processing */

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -71,8 +71,8 @@ async function createLeaderboardBlocks(timeRange) {
   const { giverScores, receiverScores } = await leaderboardScoreData(timeRange);
 
   blocks.push(leaderboardHeader());
-  blocks.push(...topGivers(giverScores));
-  blocks.push(...topReceivers(receiverScores));
+  blocks.push(topGivers(giverScores));
+  blocks.push(topReceivers(receiverScores));
   blocks.push(timeRangeInfo(timeRange));
   blocks.push(timeRangeButtons());
 
@@ -97,47 +97,47 @@ function leaderboardHeader() {
 }
 
 /*
- * Generates an array of Block Kit style objects, storing a Top Givers section
+ * Generates a Block Kit style object, storing a Top Givers section
  *    header, and leaderboard entries for provided scores.
  * @param {Array<object>} giverScores An array of objects containing a user ID
  *     and a score.
- * @return {Array<object>} An array of Block Kit style objects, storing a
+ * @return {object} A Block Kit style object, storing a
  *     section header and leaderboard entries.
  */
 function topGivers(giverScores) {
-  let content = [
-    {
-      type: "section",
-      block_id: "recognizersTitle",
-      text: {
-        type: "mrkdwn",
-        text: "*Top Givers*",
-      },
+  markdown = '*Top Givers*\n\n'
+  markdown += giverScores.map(leaderboardEntry).join('\n')
+
+  return {
+    type: "section",
+    block_id: "recognizersTitle",
+    text: {
+      type: "mrkdwn",
+      text: markdown,
     },
-  ];
-  return content.concat(giverScores.map(leaderboardEntry));
+  };
 }
 
 /*
- * Generates an array of Block Kit style objects, storing a Top Receivers section
+ * Generates a Block Kit style object, storing a Top Receivers section
  *    header, and leaderboard entries for provided scores.
  * @param {Array<object>} receiverScores An array of objects containing a user
  *     ID and a score.
- * @return {Array<object>} An array of Block Kit style objects, storing a
+ * @return {object} A Block Kit style object, storing a
  *     section header and leaderboard entries.
  */
 function topReceivers(receiverScores) {
-  let content = [
-    {
-      type: "section",
-      block_id: "recognizeesTitle",
-      text: {
-        type: "mrkdwn",
-        text: "*Top Receivers*",
-      },
+  markdown = '*Top Receivers*\n\n'
+  markdown += receiverScores.map(leaderboardEntry).join('\n')
+
+  return {
+    type: "section",
+    block_id: "recognizeesTitle",
+    text: {
+      type: "mrkdwn",
+      text: markdown,
     },
-  ];
-  return content.concat(receiverScores.map(leaderboardEntry));
+  };
 }
 
 /*
@@ -214,25 +214,17 @@ function timeRangeButtons() {
 }
 
 /*
- * Generates a Block Kit style object, containing a single leaderboard
+ * Generates a markdown string, containing a single leaderboard
  *     entry. Used with Array.map() to format score data.
  * @param {object} entry An object containing a userID and a corresponding
  *    score for a leaderboard entry.
  * @param {number} index A number denoting the rank a particular entry should
  *    be marked with in the leaderboard entry. (Ex: 1st, 2nd 3rd, etc)
- * @return {object} A Block Kit style object, storing a single leaderboard
+ * @return {string} A string of markdown, storing a single leaderboard
  *     entry.
  */
 function leaderboardEntry(entry, index) {
-  return {
-    type: "context",
-    elements: [
-      {
-        type: "mrkdwn",
-        text: `<@${entry.userID}> *${rank[index]} - Score:* ${entry.score}\n`,
-      },
-    ],
-  };
+  return `<@${entry.userID}> *${rank[index]} - Score:* ${entry.score}`
 }
 
 /* Data Processing */
@@ -303,6 +295,5 @@ function convertToScores(leaderboardData) {
   scores.sort((a, b) => {
     return b.score - a.score;
   });
-  scores.slice(0, 10);
-  return scores;
+  return scores.slice(0, 10);
 }

--- a/test/features/leaderboard.js
+++ b/test/features/leaderboard.js
@@ -1,0 +1,199 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const MockController = require("../mocks/controller");
+
+const leaderboardFeature = require("../../features/leaderboard");
+const recognition = require("../../service/recognition");
+
+describe("features/leaderboard", () => {
+  let controller;
+
+  beforeEach(async () => {
+    controller = new MockController({});
+
+    await leaderboardFeature(controller);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("a leaderboard request", () => {
+    it("should respond with a well-formed leaderboard", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves({});
+
+      await controller.userInput({
+        text: "leaderboard",
+      });
+      let response = controller.getReplies()[0].response;
+
+      expect(response.blocks[0].block_id).to.equal("leaderboardHeader");
+      expect(response.blocks[1].block_id).to.equal("topGivers");
+      expect(response.blocks[2].block_id).to.equal("topReceivers");
+      expect(response.blocks[3].block_id).to.equal("timeRange");
+      expect(response.blocks[4].block_id).to.equal("leaderboardButtons");
+    });
+
+    it("should generate leaderboard from stored data", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves([
+        {
+          recognizer: "Giver",
+          recognizee: "Receiver",
+        },
+      ]);
+
+      await controller.userInput({
+        text: "leaderboard",
+      });
+      let response = controller.getReplies()[0].response;
+
+      expect(response.blocks[1].text.text).to.include("<@Giver>");
+      expect(response.blocks[2].text.text).to.include("<@Receiver>");
+    });
+
+    it("should sort leaderboard members", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves([
+        {
+          recognizer: "GiverA",
+          recognizee: "ReceiverA",
+        },
+        {
+          recognizer: "GiverB",
+          recognizee: "ReceiverA",
+        },
+        {
+          recognizer: "GiverB",
+          recognizee: "ReceiverB",
+        },
+      ]);
+
+      await controller.userInput({
+        text: "leaderboard",
+      });
+      let response = controller.getReplies()[0].response;
+      let topGivers = response.blocks[1].text.text
+        .split("\n")
+        .filter((item) => item != "");
+
+      expect(topGivers[1]).to.include("<@GiverB>");
+      expect(topGivers[2]).to.include("<@GiverA>");
+    });
+
+    it("shouldn't include more than 10 leaderboard members per group", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves([
+        {
+          recognizer: "Giver1",
+          recognizee: "Receiver1",
+        },
+        {
+          recognizer: "Giver2",
+          recognizee: "Receiver2",
+        },
+        {
+          recognizer: "Giver3",
+          recognizee: "Receiver3",
+        },
+        {
+          recognizer: "Giver4",
+          recognizee: "Receiver4",
+        },
+        {
+          recognizer: "Giver5",
+          recognizee: "Receiver5",
+        },
+        {
+          recognizer: "Giver6",
+          recognizee: "Receiver6",
+        },
+        {
+          recognizer: "Giver7",
+          recognizee: "Receiver7",
+        },
+        {
+          recognizer: "Giver8",
+          recognizee: "Receiver8",
+        },
+        {
+          recognizer: "Giver9",
+          recognizee: "Receiver9",
+        },
+        {
+          recognizer: "Giver10",
+          recognizee: "Receiver10",
+        },
+        {
+          recognizer: "Giver11",
+          recognizee: "Receiver11",
+        },
+      ]);
+
+      await controller.userInput({
+        text: "leaderboard",
+      });
+      let response = controller.getReplies()[0].response;
+      let topGivers = response.blocks[1].text.text
+        .split("\n")
+        .filter((item) => item != "");
+      let topReceivers = response.blocks[2].text.text
+        .split("\n")
+        .filter((item) => item != "");
+
+      // Length of 11 accounts for the section header i.e. '*Top Givers*'
+      expect(topGivers).to.have.lengthOf(11);
+      expect(topReceivers).to.have.lengthOf(11);
+    });
+  });
+
+  describe("a leaderboard interactive button click", () => {
+    it("should use data from the selected time range", async () => {
+      const getRecognition = sinon
+        .stub(recognition, "getPreviousXDaysOfRecognition")
+        .resolves({});
+
+      await controller.event("block_actions", {
+        actions: [
+          {
+            block_id: "leaderboardButtons",
+            value: 365,
+          },
+        ],
+      });
+
+      expect(getRecognition.args[0][1]).to.equal(365);
+    });
+
+    it("should display the selected time range", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves({});
+
+      await controller.event("block_actions", {
+        actions: [
+          {
+            block_id: "leaderboardButtons",
+            value: 365,
+          },
+        ],
+      });
+      let response = controller.getReplies()[0].response;
+
+      expect(response.blocks[3].elements[0].text).to.equal("Last 365 days");
+    });
+  });
+
+  describe("a non-leaderboard interactive button click", () => {
+    it("should be ignored", async () => {
+      sinon.stub(recognition, "getPreviousXDaysOfRecognition").resolves({});
+
+      await controller.event("block_actions", {
+        actions: [
+          {
+            block_id: "metricButtons",
+            value: 365,
+          },
+        ],
+      });
+
+      expect(controller.getReplies()).to.be.empty;
+    });
+  });
+});

--- a/test/mocks/bot.js
+++ b/test/mocks/bot.js
@@ -59,6 +59,7 @@ const mockBot = (controller) => ({
   reply: controller.reply.bind(controller, "channel"),
   replyEphemeral: controller.reply.bind(controller, "ephemeral"),
   replyInThread: controller.reply.bind(controller, "thread"),
+  replyInteractive: controller.reply.bind(controller, "interactive"),
   replyAcknowledge: sinon.stub(),
   say: controller.reply.bind(controller, "thread", []),
   startPrivateConversation: sinon.stub(),


### PR DESCRIPTION
# Leaderboard Fixes

Fixes a few bugs in leaderboard feature, which prevented it from functioning correctly with larger datasets.
- Fix limiting of leaderboard entries to 10, previously a bug allowed more than 10 entries per section.
- Combine several Blockkit blocks into 1 for Top Givers and Top Receivers sections to more easily stay inside limit of 50.
- Update function documentation to match new usages.