### PR TITLE
Issue 27 fix recognition notification from threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ scopes to the app. Slack with automatically add scopes required for the event
 subscriptions we already set. In addition to those, we'll also need to add the
 following:
     - `chat:write`
+    - `im:write`
     - `users:read`
 
 Once again, if you're developing new functionality, you may need additional

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -231,27 +231,20 @@ async function sendNotificationToReceivers(
   recognitionInfo,
   userInfo
 ) {
-  let results = [];
   const emojiCount = (recognitionInfo.text.match(recognizeEmojiRegex) || [])
     .length;
   for (let i = 0; i < userInfo.receivers.length; i++) {
     const numberRecieved = await recognition.countRecognitionsReceived(
       userInfo.receivers[i].id
     );
-    results.push(
-      bot.say({
-        text: `You just got recognized by <@${userInfo.giver.id}> in <#${recognitionInfo.channel}> and your new balance is \`${numberRecieved}\`\n>>>${recognitionInfo.text}`,
-        channel: userInfo.receivers[i].id,
-      })
-    );
+    await bot.startPrivateConversation(userInfo.receivers[i].id);
+    await bot.say({
+      text: `You just got recognized by <@${userInfo.giver.id}> in <#${recognitionInfo.channel}> and your new balance is \`${numberRecieved}\`\n>>>${recognitionInfo.text}`,
+    });
     if (emojiCount === numberRecieved) {
-      results.push(
-        bot.say({
-          text: `I noticed this is your first time receiving a ${recognizeEmoji}. Check out <https://liatrio.atlassian.net/wiki/spaces/LE/pages/817857117/Redeeming+Fistbumps|Confluence> to see what they can be used for, or try running \`<@${message.incoming_message.recipient.id}> help\` for more information about me.`,
-          channel: userInfo.receivers[i].id,
-        })
-      );
+      await bot.say({
+        text: `I noticed this is your first time receiving a ${recognizeEmoji}. Check out <https://liatrio.atlassian.net/wiki/spaces/LE/pages/817857117/Redeeming+Fistbumps|Confluence> to see what they can be used for, or try running \`<@${message.incoming_message.recipient.id}> help\` for more information about me.`,
+      });
     }
   }
-  return Promise.all(results);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "botkit-gratibot",
       "version": "1.0.0",
       "dependencies": {
-        "botbuilder-adapter-slack": "^1.0.11",
+        "botbuilder-adapter-slack": "^1.0.12",
         "botbuilder-storage-mongodb": "^0.9.5",
         "botkit": "^4.9.0",
         "botkit-plugin-cms": "^1.0.3",
@@ -1075,9 +1075,9 @@
       }
     },
     "node_modules/botbuilder-adapter-slack": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/botbuilder-adapter-slack/-/botbuilder-adapter-slack-1.0.11.tgz",
-      "integrity": "sha512-sxIlpCeOUgng7RAl6k/HYF4pEHT8fJrNsViBeoYUZRzzksd8cX3XyOM3kH87wiNtlWc34QHPcBHQ8NEG8tgqTg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/botbuilder-adapter-slack/-/botbuilder-adapter-slack-1.0.12.tgz",
+      "integrity": "sha512-5p978U+4mXrTiry32XE7OUUAouE28ARoUmU+G2QANJ+t32rE1I8fyM/8GQ+EOLNrzHd7ncTuLlFY80p843Y8rQ==",
       "dependencies": {
         "@slack/web-api": "^5.8.0",
         "botbuilder": "^4.9.0",
@@ -7288,9 +7288,9 @@
       }
     },
     "botbuilder-adapter-slack": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/botbuilder-adapter-slack/-/botbuilder-adapter-slack-1.0.11.tgz",
-      "integrity": "sha512-sxIlpCeOUgng7RAl6k/HYF4pEHT8fJrNsViBeoYUZRzzksd8cX3XyOM3kH87wiNtlWc34QHPcBHQ8NEG8tgqTg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/botbuilder-adapter-slack/-/botbuilder-adapter-slack-1.0.12.tgz",
+      "integrity": "sha512-5p978U+4mXrTiry32XE7OUUAouE28ARoUmU+G2QANJ+t32rE1I8fyM/8GQ+EOLNrzHd7ncTuLlFY80p843Y8rQ==",
       "requires": {
         "@slack/web-api": "^5.8.0",
         "botbuilder": "^4.9.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint-fix": "eslint '*.js' 'features/**' 'test/**' --fix"
   },
   "dependencies": {
-    "botbuilder-adapter-slack": "^1.0.11",
+    "botbuilder-adapter-slack": "^1.0.12",
     "botbuilder-storage-mongodb": "^0.9.5",
     "botkit": "^4.9.0",
     "botkit-plugin-cms": "^1.0.3",


### PR DESCRIPTION
Fixes #27

Uses Botkit's startPrivateConversation method to set conversation context before sending notifications to receivers of a fistbump.
This fixes a bug where notifications wouldn't be sent if a fistbump was originally sent in a thread.

Updates OAuth scopes to include im:write, which is required for startPrivateConversation.
Update Botkit Slack Adapter to version 1.0.12, to properly support conversation API while using startPrivateConversation.