### PR TITLE
Issue 41 Unit Testing

### DIFF
--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -335,5 +335,28 @@ describe("features/recognize", () => {
 
       expect(giveRecognition.called).to.be.false;
     });
+    it("shouldn't update database if original message didn't include emoji", async () => {
+      const giveRecognition = sinon
+        .stub(recognition, "giveRecognition")
+        .resolves("");
+      sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+
+      controller.bot.api.conversations.history.resolves({
+        messages: [{ text: "<@Receiver> Test Test Test Test Test" }],
+      });
+
+      await controller.event("reaction_added", {
+        reaction: ":nail_care:",
+        user: "Giver",
+        item: {
+          type: "message",
+          channel: "SomeChannel",
+          ts: "1",
+        },
+      });
+
+      expect(giveRecognition.called).to.be.false;
+    });
   });
 });

--- a/test/service/balance.js
+++ b/test/service/balance.js
@@ -4,6 +4,7 @@ const expect = require("chai").expect;
 const config = require("../../config");
 const balance = require("../../service/balance");
 const recognitionCollection = require("../../database/recognitionCollection");
+const deductionCollection = require("../../database/deductionCollection");
 
 describe("service/balance", () => {
   afterEach(() => {
@@ -31,6 +32,34 @@ describe("service/balance", () => {
       );
 
       expect(result).to.equal(9);
+    });
+  });
+  describe("currentBalance", () => {
+    it("should return total earnings when users have no deductions", async () => {
+      sinon.stub(recognitionCollection, "count").resolves(100);
+      sinon.stub(deductionCollection, "find").resolves([]);
+
+      const result = await balance.currentBalance("User");
+
+      expect(result).to.equal(100);
+    });
+  });
+  describe("lifetimeSpendings", () => {
+    it("should sum the total deduction value returned from the db", async () => {
+      sinon.stub(deductionCollection, "find").resolves([
+        {
+          user: "User",
+          value: 10,
+        },
+        {
+          user: "User",
+          value: 10,
+        },
+      ]);
+
+      const result = await balance.lifetimeSpendings("User");
+
+      expect(result).to.equal(20);
     });
   });
 });

--- a/test/service/deduction.js
+++ b/test/service/deduction.js
@@ -1,0 +1,77 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const deduction = require("../../service/deduction");
+const deductionCollection = require("../../database/deductionCollection");
+
+describe("deduction/balance", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("createDeduction", () => {
+    it("should insert data into db", async () => {
+      const insert = sinon.stub(deductionCollection, "insert").resolves({});
+      sinon.useFakeTimers(new Date(2020, 1, 1));
+
+      await deduction.createDeduction("User", 10, "Test Message");
+
+      const object = {
+        user: "User",
+        timestamp: new Date(2020, 1, 1),
+        value: 10,
+        message: "Test Message",
+      };
+      expect(insert.args[0][0]).to.deep.equal(object);
+    });
+    it("should allow for message to be optional", async () => {
+      const insert = sinon.stub(deductionCollection, "insert").resolves({});
+      sinon.useFakeTimers(new Date(2020, 1, 1));
+
+      await deduction.createDeduction("User", 10);
+
+      const object = {
+        user: "User",
+        timestamp: new Date(2020, 1, 1),
+        value: 10,
+        message: "",
+      };
+      expect(insert.args[0][0]).to.deep.equal(object);
+    });
+  });
+  describe("createDeduction", () => {
+    it("should return deductions found in db", async () => {
+      sinon.stub(deductionCollection, "find").resolves([
+        {
+          user: "User",
+          value: 100,
+        },
+      ]);
+
+      const result = await deduction.getDeductions("User");
+
+      const object = [
+        {
+          user: "User",
+          value: 100,
+        },
+      ];
+      expect(result).to.deep.equal(object);
+    });
+    it("should filter results if times are specified", async () => {
+      const find = sinon.stub(deductionCollection, "find").resolves([]);
+      sinon.useFakeTimers(new Date(Date.UTC(2020, 1, 1)));
+
+      await deduction.getDeductions("User", "America/Los_Angeles", 2);
+
+      const filter = {
+        user: "User",
+        timestamp: {
+          $gte: new Date(Date.UTC(2020, 0, 30, 8)),
+        },
+      };
+
+      expect(find.args[0][0]).to.deep.equal(filter);
+    });
+  });
+});

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -1,0 +1,134 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const recognition = require("../../service/recognition");
+const recognitionCollection = require("../../database/recognitionCollection");
+
+describe("service/recognition", () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("giveRecognition", () => {
+    it("should insert data into db", async () => {
+      const insert = sinon.stub(recognitionCollection, "insert").resolves({});
+      sinon.useFakeTimers(new Date(2020, 1, 1));
+
+      await recognition.giveRecognition(
+        "Giver",
+        "Receiver",
+        "Test Message",
+        "Test Channel",
+        ["Test Tag"]
+      );
+
+      const object = {
+        recognizer: "Giver",
+        recognizee: "Receiver",
+        timestamp: new Date(2020, 1, 1),
+        message: "Test Message",
+        channel: "Test Channel",
+        values: ["Test Tag"],
+      };
+      expect(insert.args[0][0]).to.deep.equal(object);
+    });
+  });
+  describe("countRecognitionsReceived", () => {
+    it("should return count of recognition in db", async () => {
+      sinon.stub(recognitionCollection, "count").resolves(10);
+
+      const result = await recognition.countRecognitionsReceived("User");
+
+      expect(result).to.equal(10);
+    });
+    it("should filter results if times are specified", async () => {
+      const count = sinon.stub(recognitionCollection, "count").resolves(0);
+      sinon.useFakeTimers(new Date(Date.UTC(2020, 1, 1)));
+
+      await recognition.countRecognitionsReceived(
+        "User",
+        "America/Los_Angeles",
+        2
+      );
+
+      const filter = {
+        recognizee: "User",
+        timestamp: {
+          $gte: new Date(Date.UTC(2020, 0, 30, 8)),
+        },
+      };
+
+      expect(count.args[0][0]).to.deep.equal(filter);
+    });
+  });
+  describe("countRecognitionsGiven", () => {
+    it("should return count of recognition in db", async () => {
+      sinon.stub(recognitionCollection, "count").resolves(10);
+
+      const result = await recognition.countRecognitionsGiven("User");
+
+      expect(result).to.equal(10);
+    });
+    it("should filter results if times are specified", async () => {
+      const count = sinon.stub(recognitionCollection, "count").resolves(0);
+      sinon.useFakeTimers(new Date(Date.UTC(2020, 1, 1)));
+
+      await recognition.countRecognitionsGiven(
+        "User",
+        "America/Los_Angeles",
+        2
+      );
+
+      const filter = {
+        recognizer: "User",
+        timestamp: {
+          $gte: new Date(Date.UTC(2020, 0, 30, 8)),
+        },
+      };
+
+      expect(count.args[0][0]).to.deep.equal(filter);
+    });
+  });
+  describe("getPreviousXDaysOfRecognition", () => {
+    it("should return recognition in db", async () => {
+      sinon.stub(recognitionCollection, "find").resolves([
+        {
+          recognizer: "Giver",
+          recognizee: "Receiver",
+          timestamp: new Date(2020, 1, 1),
+          message: "Test Message",
+          channel: "Test Channel",
+          values: ["Test Tag"],
+        },
+      ]);
+
+      const result = await recognition.getPreviousXDaysOfRecognition();
+
+      const object = [
+        {
+          recognizer: "Giver",
+          recognizee: "Receiver",
+          timestamp: new Date(2020, 1, 1),
+          message: "Test Message",
+          channel: "Test Channel",
+          values: ["Test Tag"],
+        },
+      ];
+      expect(result).to.deep.equal(object);
+    });
+    it("should filter results if times are specified", async () => {
+      const find = sinon.stub(recognitionCollection, "find").resolves([]);
+      sinon.useFakeTimers(new Date(Date.UTC(2020, 1, 1)));
+
+      await recognition.getPreviousXDaysOfRecognition("America/Los_Angeles", 2);
+
+      const filter = {
+        timestamp: {
+          $gte: new Date(Date.UTC(2020, 0, 30, 8)),
+        },
+      };
+
+      expect(find.args[0][0]).to.deep.equal(filter);
+    });
+  });
+});


### PR DESCRIPTION
Expand unit testing of 'service/' package, in addition to covering an extra case when giving recognition via reaction.

Closes #41 