### PR TITLE
Adding additional TF files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,38 @@ dist
 # VsCode
 .vscode/
 
-tf/*.tfstate
-tf/.terraform
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+*.lock.hcl


### PR DESCRIPTION
Adding additional files to the gitignore to prevent `vars` or other local Terraform artifacts from being committed to Git. Especially useful for those that run `tf plan` to validate prod deployments