### PR TITLE
Issue 50 recognition emoji in threads

### DIFF
--- a/features/recognize.js
+++ b/features/recognize.js
@@ -65,11 +65,10 @@ async function respondToRecognitionReaction(bot, message) {
   // TODO: Error handle this API call
   // Consider refactoring API calls for standardized error handling
   const messageReactedTo = (
-    await bot.api.conversations.history({
+    await bot.api.conversations.replies({
       channel: message.item.channel,
-      latest: message.item.ts,
+      ts: message.item.ts,
       limit: 1,
-      inclusive: true,
     })
   ).messages[0];
 

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -269,7 +269,7 @@ describe("features/recognize", () => {
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-      controller.bot.api.conversations.history.resolves({
+      controller.bot.api.conversations.replies.resolves({
         messages: [{ text: ":fistbump: <@Receiver> Test Test Test Test Test" }],
       });
 
@@ -293,7 +293,7 @@ describe("features/recognize", () => {
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-      controller.bot.api.conversations.history.resolves({
+      controller.bot.api.conversations.replies.resolves({
         messages: [
           { text: ":fistbump: <@NotARealUser> Test Test Test Test Test" },
         ],
@@ -319,7 +319,7 @@ describe("features/recognize", () => {
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-      controller.bot.api.conversations.history.resolves({
+      controller.bot.api.conversations.replies.resolves({
         messages: [{ text: ":fistbump: <@Receiver> Test Test Test Test Test" }],
       });
 
@@ -342,7 +342,7 @@ describe("features/recognize", () => {
       sinon.stub(recognition, "countRecognitionsReceived").resolves(1);
       sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
 
-      controller.bot.api.conversations.history.resolves({
+      controller.bot.api.conversations.replies.resolves({
         messages: [{ text: "<@Receiver> Test Test Test Test Test" }],
       });
 

--- a/test/mocks/bot.js
+++ b/test/mocks/bot.js
@@ -21,6 +21,7 @@ const mockBot = (controller) => ({
     },
     conversations: {
       history: sinon.stub(),
+      replies: sinon.stub(),
     },
     reactions: {
       add: function (reaction) {


### PR DESCRIPTION
Fixes #50 

Replaces the use of `conversations.history` with `conversations.replies` while looking up the original message of a reaction-based recognition.

`history` will only return top level messages in a channel, which could cause problems in some cases when sending a reaction-based recognition on a message in a thread. Using `replies` instead should resolve this issue, as it will properly find original messages even if they are in threads.