### PR TITLE
Add a terraform plan prior to apply

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -27,6 +27,32 @@ jobs:
         run: docker push $IMAGE_NAME:${{ steps.tag.outputs.tag }}
     outputs:
       docker_tag: ${{ steps.tag.outputs.tag }}
+  plan:
+    name: "Terraform Prod plan"
+    runs-on: ubuntu-latest
+    environment:
+      name: "prod-plan"
+    container: "hashicorp/terraform:0.14.10"
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Plan Gratibot prod deployment
+        working-directory: tf
+        run: |
+          terraform init -backend-config=backends/prod.tf
+          terraform plan
+        env:
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          ARM_TENANT_ID: "1b4a4fed-fed8-4823-a8a0-3d5cea83d122"
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}
+          TF_VAR_acr_subscription_id: ${{ secrets.AZURE_PROD_SUBSCRIPTION_ID }}
+          TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
+          TF_VAR_environment: "prod"
+          TF_VAR_signing_secret: ${{ secrets.PROD_PLAN_SIGNING_SECRET }}
+          TF_VAR_bot_user_token: ${{ secrets.PROD_PLAN_BOT_TOKEN }}
+          TF_VAR_gratibot_recognize_emoji: ":fistbump:"
   apply:
     name: "Terraform Apply"
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new plan job to the prod workflow to allow users to see the results of a `terraform plan` prior to approving the prod deployment.