### PR TITLE
Add both jobs as dependencies for grabbing output

### DIFF
--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -60,7 +60,7 @@ jobs:
     environment:
       name: "prod"
     container: "hashicorp/terraform:0.14.10"
-    needs: plan
+    needs: [build, plan]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This will fix the issue with prod deploying an empty tag. Previous PRs broke the apply job's access to `build.outputs`

See [here](https://github.com/liatrio/gratibot/blob/341f7cd2ecebdb40cd4f1de111754977e024c2a2/.github/workflows/prod.yaml#L79)