### PR TITLE
Refactor Recognize Feature

### DIFF
--- a/service/errors.js
+++ b/service/errors.js
@@ -1,0 +1,24 @@
+class SlackError extends Error {
+  
+  constructor (apiMethod, apiError, userMessage, message) {
+    super(message);
+
+    this.apiMethod = apiMethod;
+    this.apiError = apiError;
+    this.userMessage = userMessage;
+  }
+}
+
+class GratitudeError extends Error {
+
+  constructor (gratitudeErrors, message) {
+    super(message);
+
+    this.gratitudeErrors = gratitudeErrors;
+  }
+}
+
+module.exports = {
+  SlackError,
+  GratitudeError
+}

--- a/service/errors.js
+++ b/service/errors.js
@@ -1,5 +1,5 @@
 class SlackError extends Error {
-  
+
   constructor (apiMethod, apiError, userMessage, message) {
     super(message);
 

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -1,6 +1,16 @@
+const config = require("../config")
 const moment = require('moment-timezone');
 const recognitionCollection = require('../database/recognitionCollection');
+const balance = require("./balance");
 
+const { recognizeEmoji, maximum, minimumMessageLength, reactionEmoji } = config;
+
+const userRegex = /<@([a-zA-Z0-9]+)>/g;
+const tagRegex = /#(\S+)/g;
+const generalEmojiRegex = /:([a-z-_']+):/g;
+const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
+
+// TODO Can we add a 'count' field to the recognition?
 async function giveRecognition(recognizer, recognizee, message, channel, values) {
   console.debug('Sending a recognition given to database');
   let timestamp = new Date();
@@ -60,9 +70,113 @@ async function getPreviousXDaysOfRecognition(timezone = null, days = null) {
   return await recognitionCollection.find(filter);
 }
 
+function gratitudeReceiverIdsIn(text) {
+  return (text.match(userRegex) || [])
+    .map((userMention) => userMention.slice(2, -1));
+}
+
+function gratitudeCountIn(text) {
+  return (text.match(gratitudeEmojiRegex) || []).length;
+}
+
+function gratitudeTagsIn(text) {
+  return (text.match(tagRegex) || [])
+    .map((tag) => tag.slice(1)); 
+}
+
+function trimmedGratitudeMessage(text) {
+  return text
+    .replace(userRegex, "")
+    .replace(generalEmojiRegex, "");
+}
+
+async function isGratitudeAffordable(gratitude) {
+  const dailyGratitudeRemaining = await balance.dailyGratitudeRemaining(
+    gratitude.giver.id,
+    gratitude.giver.tz
+  );
+  const gratitudeCost = gratitude.receivers.length * gratitude.count;
+  return dailyGratitudeRemaining >= gratitudeCost;
+}
+
+async function gratitudeErrors(gratitude) {
+  return [
+    gratitude.receivers.length === 0
+      ? "- Mention who you want to recognize with @user"
+      : "",
+    gratitude.receivers.find((x) => x.id == gratitude.giver.id)
+      ? "- You can't recognize yourself"
+      : "",
+    gratitude.giver.is_bot ? "- Bots can't give recognition" : "",
+    gratitude.giver.is_restricted ? "- Guest users can't give recognition" : "",
+    gratitude.receivers.find((x) => x.is_bot)
+      ? "- You can't give recognition to bots"
+      : "",
+    gratitude.receivers.find((x) => x.is_restricted)
+      ? "- You can' give recognition to guest users"
+      : "",
+    gratitude.trimmedMessage.length < minimumMessageLength
+      ? `- Your message must be at least ${minimumMessageLength} characters`
+      : "",
+    !(await isGratitudeAffordable(gratitude))
+      ? `- A maximum of ${maximum} ${recognizeEmoji} can be sent per day`
+      : "",
+  ]
+    .filter((x) => x !== "")
+    .join("\n");
+}
+
+async function giveGratitude(gratitude) {
+  let results = [];
+  for (let i = 0; i < gratitude.receivers.length; i++) {
+    for (let j = 0; j < gratitude.count; j++) {
+      results.push(
+        giveRecognition(
+          gratitude.giver.id,
+          gratitude.receivers[i].id,
+          gratitude.text,
+          gratitude.channel,
+          gratitude.tags
+        )
+      );
+    }
+  }
+  return Promise.all(results);
+}
+
+
+
+/*
+ * Gratitude Object
+ *
+ * {
+ *   giver: {
+ *     id: string,
+ *     tz: string,
+ *     is_bot: bool,
+ *     is_restricted: bool,
+ *   },
+ *   receivers: [{
+ *     id: string, 
+ *     is_bot: bool,
+ *     is_restricted: bool,
+ *   }]
+ *   count: number,
+ *   message: string,
+ *   trimmedMessage: string,
+ *   channel: string,
+ *   tags [string],
+ * }
+ */
 module.exports = {
     giveRecognition,
     countRecognitionsReceived,
     countRecognitionsGiven,
-    getPreviousXDaysOfRecognition
+    getPreviousXDaysOfRecognition,
+    gratitudeReceiverIdsIn,
+    gratitudeCountIn,
+    gratitudeErrors,
+    trimmedGratitudeMessage,
+    gratitudeTagsIn,
+    giveGratitude
 }

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -2,6 +2,7 @@ const config = require("../config")
 const moment = require('moment-timezone');
 const recognitionCollection = require('../database/recognitionCollection');
 const balance = require("./balance");
+const { GratitudeError } = require("./errors")
 
 const { recognizeEmoji, maximum, minimumMessageLength, reactionEmoji } = config;
 
@@ -122,8 +123,7 @@ async function gratitudeErrors(gratitude) {
       ? `- A maximum of ${maximum} ${recognizeEmoji} can be sent per day`
       : "",
   ]
-    .filter((x) => x !== "")
-    .join("\n");
+    .filter((x) => x !== "");
 }
 
 async function giveGratitude(gratitude) {
@@ -144,6 +144,13 @@ async function giveGratitude(gratitude) {
   return Promise.all(results);
 }
 
+async function validateAndSendGratitude(gratitude) {
+  const errors = await gratitudeErrors(gratitude);
+  if (errors) {
+    throw new GratitudeError(errors)
+  }
+  return giveGratitude(gratitude);
+}
 
 
 /*
@@ -178,5 +185,6 @@ module.exports = {
     gratitudeErrors,
     trimmedGratitudeMessage,
     gratitudeTagsIn,
-    giveGratitude
+    giveGratitude,
+    validateAndSendGratitude
 }

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -14,7 +14,6 @@ const multiplierRegex = /x([0-9]+)/;
 
 // TODO Can we add a 'count' field to the recognition?
 async function giveRecognition(recognizer, recognizee, message, channel, values) {
-  console.debug('Sending a recognition given to database');
   let timestamp = new Date();
   return await recognitionCollection.insert(
   {
@@ -28,7 +27,6 @@ async function giveRecognition(recognizer, recognizee, message, channel, values)
 }
 
 async function countRecognitionsReceived(user, timezone = null, days = null) {
-  console.debug('Getting the recognitions a user received');
   let filter = {recognizee:user}
   if(days && timezone) {
     let userDate = moment(Date.now()).tz(timezone);
@@ -43,7 +41,6 @@ async function countRecognitionsReceived(user, timezone = null, days = null) {
 }
 
 async function countRecognitionsGiven (user, timezone = null, days = null) {
-  console.debug('Getting the recognitions a user gave');
   let filter = {recognizer:user}
   if(days && timezone) {
     let userDate = moment(Date.now()).tz(timezone);
@@ -87,7 +84,7 @@ function gratitudeCountIn(text) {
 
 function gratitudeTagsIn(text) {
   return (text.match(tagRegex) || [])
-    .map((tag) => tag.slice(1)); 
+    .map((tag) => tag.slice(1));
 }
 
 function trimmedGratitudeMessage(text) {
@@ -119,7 +116,7 @@ async function gratitudeErrors(gratitude) {
       ? "- You can't give recognition to bots"
       : "",
     gratitude.receivers.find((x) => x.is_restricted)
-      ? "- You can' give recognition to guest users"
+      ? "- You can't give recognition to guest users"
       : "",
     gratitude.trimmedMessage.length < minimumMessageLength
       ? `- Your message must be at least ${minimumMessageLength} characters`
@@ -151,7 +148,7 @@ async function giveGratitude(gratitude) {
 
 async function validateAndSendGratitude(gratitude) {
   const errors = await gratitudeErrors(gratitude);
-  if (errors) {
+  if (errors.length > 0) {
     throw new GratitudeError(errors)
   }
   return giveGratitude(gratitude);

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -2,6 +2,7 @@ const sinon = require("sinon");
 const expect = require("chai").expect;
 
 const recognition = require("../../service/recognition");
+const balance = require("../../service/balance");
 const recognitionCollection = require("../../database/recognitionCollection");
 
 describe("service/recognition", () => {
@@ -129,6 +130,469 @@ describe("service/recognition", () => {
       };
 
       expect(find.args[0][0]).to.deep.equal(filter);
+    });
+  });
+
+  describe("gratitudeReceiverIdsIn", () => {
+    it("should find single user mentioned in message", async () => {
+      const text = ":fistbump: <@TestUser> Test Message";
+      const results = recognition.gratitudeReceiverIdsIn(text);
+      expect(results).to.deep.equal(["TestUser"]);
+    });
+
+    it("should find multiple users mentioned in message", async () => {
+      const text = ":fistbump: <@TestUserOne> <@TestUserTwo> Test Message";
+      const results = recognition.gratitudeReceiverIdsIn(text);
+      expect(results).to.deep.equal(["TestUserOne", "TestUserTwo"]);
+    });
+
+    it("should return empty when no users are mentioned in message", async () => {
+      const text = ":fistbump: Test Message";
+      const results = recognition.gratitudeReceiverIdsIn(text);
+      expect(results).to.deep.equal([]);
+    });
+  });
+
+  describe("gratitudeCountIn", () => {
+    it("should add all fistbumps in the message", async () => {
+      const text = ":fistbump: :fistbump: <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(2);
+    });
+
+    it("should return zero when message has no fistbumps", async () => {
+      const text = "<@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(0);
+    });
+
+    it("should support multiplication", async () => {
+      const text = ":fistbump: x5 <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(5);
+    });
+
+    it("should support multiplication along with multiple emoji", async () => {
+      const text = ":fistbump: :fistbump: x2 <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(4);
+    });
+
+    it("shouldn't multiply by negative numbers", async () => {
+      const text = ":fistbump: x-6 <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(1);
+    });
+  });
+
+  describe("gratitudeTagsIn", () => {
+    it("should find a tag in message", async () => {
+      const text = ":fistbump: <@TestUser> Test Message #TestTag";
+      const result = recognition.gratitudeTagsIn(text);
+      expect(result).to.deep.equal(["TestTag"]);
+    });
+
+    it("should find multiple tags in message", async () => {
+      const text =
+        ":fistbump: <@TestUser> Test Message #TestTagOne #TestTagTwo";
+      const result = recognition.gratitudeTagsIn(text);
+      expect(result).to.deep.equal(["TestTagOne", "TestTagTwo"]);
+    });
+
+    it("should return empty with no tags", async () => {
+      const text = ":fistbump: <@TestUser> Test Message";
+      const result = recognition.gratitudeTagsIn(text);
+      expect(result).to.deep.equal([]);
+    });
+  });
+
+  describe("trimmedGratitudeMessage", () => {
+    it("should remove user mentions from message", async () => {
+      const text = "<@TestUser> Test Message";
+      const result = recognition.trimmedGratitudeMessage(text);
+      expect(result).to.equal(" Test Message");
+    });
+
+    it("should remove emojis from message", async () => {
+      const text = ":fistbump: Test Message";
+      const result = recognition.trimmedGratitudeMessage(text);
+      expect(result).to.equal(" Test Message");
+    });
+
+    it("should return input if no user mentions or emojis are in message", async () => {
+      const text = "Test Message";
+      const result = recognition.trimmedGratitudeMessage(text);
+      expect(result).to.equal("Test Message");
+    });
+  });
+
+  describe("gratitudeErrors", () => {
+    it("should return empty if gratitude is okay", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal([]);
+    });
+
+    it("should return error if no receivers", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal([
+        "- Mention who you want to recognize with @user",
+      ]);
+    });
+
+    it("should return error on self-recognition", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Giver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal(["- You can't recognize yourself"]);
+    });
+
+    it("should return error if giver is a bot", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: true,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal(["- Bots can't give recognition"]);
+    });
+
+    it("should return error if giver is a guest user", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: true,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal(["- Guest users can't give recognition"]);
+    });
+
+    it("should return error if receiver is a bot", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: true,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal(["- You can't give recognition to bots"]);
+    });
+
+    it("should return error if receiver is a guest user", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: true,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal([
+        "- You can't give recognition to guest users",
+      ]);
+    });
+
+    it("should return error if message is too short", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal([
+        "- Your message must be at least 20 characters",
+      ]);
+    });
+
+    it("should return error if giver can't afford recognition", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(0);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      const result = await recognition.gratitudeErrors(gratitude);
+      expect(result).to.deep.equal([
+        "- A maximum of 5 :fistbump: can be sent per day",
+      ]);
+    });
+  });
+
+  describe("giveGratitude", () => {
+    it("should add gratitude to database", async () => {
+      const insert = sinon.stub(recognitionCollection, "insert").resolves({});
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+      await recognition.giveGratitude(gratitude);
+
+      expect(insert.called).to.be.true;
+    });
+
+    it("should add multiple gratitude to database", async () => {
+      const insert = sinon.stub(recognitionCollection, "insert").resolves({});
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 2,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+      await recognition.giveGratitude(gratitude);
+
+      expect(insert.calledTwice).to.be.true;
+    });
+  });
+  describe("validateAndSendGratitude", () => {
+    it("should add gratitude to database if okay", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      const insert = sinon.stub(recognitionCollection, "insert").resolves({});
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+      await recognition.validateAndSendGratitude(gratitude);
+
+      expect(insert.called).to.be.true;
+    });
+
+    it("should throw error if not okay", async () => {
+      sinon.stub(balance, "dailyGratitudeRemaining").resolves(0);
+      const gratitude = {
+        giver: {
+          id: "Giver",
+          tz: "America/Los_Angeles",
+          is_bot: false,
+          is_restricted: false,
+        },
+        receivers: [
+          {
+            id: "Receiver",
+            tz: "America/Los_Angeles",
+            is_bot: false,
+            is_restricted: false,
+          },
+        ],
+        count: 1,
+        message: ":fistbump: <@Receiver> Test Message 1234567890",
+        trimmedMessage: "  Test Message 1234567890",
+        channel: "TestChannel",
+        tags: [],
+      };
+
+      expect(recognition.validateAndSendGratitude(gratitude)).to.be.rejected;
     });
   });
 });


### PR DESCRIPTION
Moves logic out of `features/` module and into `service/` module, to the extent possible.

With this refactor, any Botkit specific logic, such as functions using the 'bot' or 'message' objects, are contained in features. Any logic that is not specific to Botkit is moved to service. This should ease a possible move away from Botkit in the future.

This refactor also defines a more standard error handling pattern for ensuring that users aren't left with no response in the case of unexpected Gratibot failures.

This feature can likely be refactored further, and other features also need more separation between logical components, however those changes are left out of this PR to keep the scope of changes smaller. 