### PR TITLE
Add Gratitude Values to Notifications

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,7 +8,7 @@ config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ":fistbump:";
 config.reactionEmoji = process.env.REACTION_EMOJI || ":nail_care:";
 config.maximum = 5;
 config.minimumMessageLength = 20;
-config.botName = process.env.BOT_NAME || "gratibot"
+config.botName = process.env.BOT_NAME || "gratibot";
 
 config.usersExemptFromMaximum = ["U037FL37G"];
 

--- a/config.js
+++ b/config.js
@@ -8,6 +8,7 @@ config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ":fistbump:";
 config.reactionEmoji = process.env.REACTION_EMOJI || ":nail_care:";
 config.maximum = 5;
 config.minimumMessageLength = 20;
+config.botName = process.env.BOT_NAME || "gratibot"
 
 config.usersExemptFromMaximum = ["U037FL37G"];
 

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -56,7 +56,7 @@ async function respondToRecognitionMessage(bot, message) {
     sendNotificationToReceivers(bot, message, gratitude),
     bot.replyEphemeral(
       message,
-      `Your ${recognizeEmoji} has been sent. You have \`${gratitudeRemaining}\` left to give today.`
+      await recognition.giverSlackNotification(gratitude),
     ),
   ]);
 }
@@ -116,7 +116,7 @@ async function respondToRecognitionReaction(bot, message) {
     sendNotificationToReceivers(bot, message, gratitude),
     bot.replyEphemeral(
       message,
-      `Your ${recognizeEmoji} has been sent. You have \`${gratitudeRemaining}\` left to give today.`
+      await recognition.giverSlackNotification(gratitude),
     ),
   ]);
 }
@@ -181,19 +181,10 @@ async function handleGenericError(bot, message, error) {
 }
 
 async function sendNotificationToReceivers(bot, message, gratitude) {
-  const emojiCount = recognition.gratitudeCountIn(gratitude.message);
   for (let i = 0; i < gratitude.receivers.length; i++) {
-    const numberRecieved = await recognition.countRecognitionsReceived(
-      gratitude.receivers[i].id
+    await bot.startPrivateConversation(gratitude.giver.id);
+    await bot.say(
+      await recognition.receiverSlackNotification(gratitude, gratitude.receivers[i].id)
     );
-    await bot.startPrivateConversation(gratitude.receivers[i].id);
-    await bot.say({
-      text: `You just got recognized by <@${gratitude.giver.id}> in <#${gratitude.channel}> and your new balance is \`${numberRecieved}\`\n>>>${gratitude.message}`,
-    });
-    if (emojiCount === numberRecieved) {
-      await bot.say({
-        text: `I noticed this is your first time receiving a ${recognizeEmoji}. Check out <https://liatrio.atlassian.net/wiki/spaces/LE/pages/817857117/Redeeming+Fistbumps|Confluence> to see what they can be used for, or try running \`<@${message.incoming_message.recipient.id}> help\` for more information about me.`,
-      });
-    }
   }
 }

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -1,6 +1,5 @@
 const config = require("../config");
 const recognition = require("../service/recognition");
-const balance = require("../service/balance");
 const winston = require("../winston");
 const { SlackError, GratitudeError } = require("../service/errors");
 
@@ -47,16 +46,12 @@ async function respondToRecognitionMessage(bot, message) {
       return handleGenericError(bot, message, e);
     }
   }
-  const gratitudeRemaining = await balance.dailyGratitudeRemaining(
-    gratitude.giver.id,
-    gratitude.giver.tz
-  );
 
   return Promise.all([
     sendNotificationToReceivers(bot, message, gratitude),
     bot.replyEphemeral(
       message,
-      await recognition.giverSlackNotification(gratitude),
+      await recognition.giverSlackNotification(gratitude)
     ),
   ]);
 }
@@ -107,16 +102,11 @@ async function respondToRecognitionReaction(bot, message) {
     }
   }
 
-  const gratitudeRemaining = await balance.dailyGratitudeRemaining(
-    gratitude.giver.id,
-    gratitude.giver.tz
-  );
-
   return Promise.all([
     sendNotificationToReceivers(bot, message, gratitude),
     bot.replyEphemeral(
       message,
-      await recognition.giverSlackNotification(gratitude),
+      await recognition.giverSlackNotification(gratitude)
     ),
   ]);
 }
@@ -184,7 +174,10 @@ async function sendNotificationToReceivers(bot, message, gratitude) {
   for (let i = 0; i < gratitude.receivers.length; i++) {
     await bot.startPrivateConversation(gratitude.giver.id);
     await bot.say(
-      await recognition.receiverSlackNotification(gratitude, gratitude.receivers[i].id)
+      await recognition.receiverSlackNotification(
+        gratitude,
+        gratitude.receivers[i].id
+      )
     );
   }
 }

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -5,7 +5,6 @@ const MockController = require("../mocks/controller");
 
 const recognizeFeature = require("../../features/recognize");
 const recognition = require("../../service/recognition");
-const balance = require("../../service/balance");
 const { GratitudeError } = require("../../service/errors");
 
 describe("features/recognize", () => {
@@ -57,8 +56,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       await controller.userInput({
         text: ":fistbump: <@Receiver> Test Message",
@@ -66,28 +69,7 @@ describe("features/recognize", () => {
       });
 
       const reply = controller.getReplies()[0].response;
-      expect(reply).to.include("Your :fistbump: has been sent.");
-    });
-
-    it("should send addition response to first time receivers", async () => {
-      sinon.stub(recognition, "validateAndSendGratitude").resolves("");
-      sinon.stub(recognition, "gratitudeReceiverIdsIn").returns(["Receiver"]);
-      sinon.stub(recognition, "gratitudeCountIn").returns(1);
-      sinon
-        .stub(recognition, "trimmedGratitudeMessage")
-        .returns("Test Message");
-      sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(recognition, "countRecognitionsReceived").returns(1);
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-
-      await controller.userInput({
-        text: ":fistbump: <@Receiver> Test Message",
-        user: "Giver",
-      });
-
-      const replies = controller.getReplies();
-      expect(replies[0].response).to.include("Your :fistbump: has been sent.");
-      expect(replies[2].response.text).to.include("first time receiving");
+      expect(reply).to.include("Test Giver Notification");
     });
 
     it("should respond with error when user info can't be found", async () => {
@@ -100,8 +82,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       await controller.userInput({
         text: ":fistbump: <@NotARealUser> Test Message",
@@ -122,8 +108,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       await controller.userInput({
         text: ":fistbump: <@Receiver> Test Message",
@@ -144,8 +134,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       await controller.userInput({
         text: ":fistbump: <@Receiver> Test Message",
@@ -166,8 +160,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: true,
@@ -185,7 +183,7 @@ describe("features/recognize", () => {
       });
 
       const reply = controller.getReplies()[0].response;
-      expect(reply).to.include("Your :fistbump: has been sent.");
+      expect(reply).to.include("Test Giver Notification");
     });
 
     it("should respond with error when original message can't be found", async () => {
@@ -196,8 +194,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: false,
@@ -228,8 +230,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: true,
@@ -260,8 +266,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: true,
@@ -290,8 +300,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: true,
@@ -319,8 +333,12 @@ describe("features/recognize", () => {
         .stub(recognition, "trimmedGratitudeMessage")
         .returns("Test Message");
       sinon.stub(recognition, "gratitudeTagsIn").returns("");
-      sinon.stub(balance, "dailyGratitudeRemaining").resolves(5);
-      sinon.stub(recognition, "countRecognitionsReceived").returns(10);
+      sinon
+        .stub(recognition, "giverSlackNotification")
+        .resolves("Test Giver Notification");
+      sinon
+        .stub(recognition, "receiverSlackNotification")
+        .resolves("Test Receiver Notification");
 
       controller.bot.api.conversations.replies.resolves({
         ok: true,


### PR DESCRIPTION
Updates the format of notifications for both givers and receivers of gratitude to include the amount given/received.

(Messages below are non-exact)
Previously messages were ambiguous about the amounts:

> You got recognized by x and your new balance is 5

> Your fistbump has been sent you have 3 left to give away today

New messages are explicit about amounts:

> You got recognized by x. You earned 2 and your new balance is 5

> Your 2 fistbumps have been sent. You have 3 left to give away today.

---

This PR also moves some messaging logic out of the `features/` package. This further removes functionality from the package, so as to limit its domain to Botkit specific actions. 

---

Closes #63 when released.