### PR TITLE
Fix typo in help message

### DIFF
--- a/features/help.js
+++ b/features/help.js
@@ -76,7 +76,7 @@ and receiving the most recognition.
 *View Metrics*
 
 Send me a direct message with 'metrics' and I'll show you how many times \
-people have given recognition over the last month.
+people have given recognitions over the last month.
 
 
 


### PR DESCRIPTION
I noticed a typo in our help message for Gratibot. This PR will fix `recognition` to `recognitons`