### PR TITLE
Update Dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.12.0-alpine3.10
+FROM node:15.14.0-alpine3.10
 WORKDIR /app
 
 COPY package*.json ./

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,13 +21,13 @@
         "chance": "^1.1.6",
         "codecov": "^3.8.1",
         "eslint": "^7.2.0",
-        "eslint-config-prettier": "^6.11.0",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^3.1.4",
         "mocha": "^8.0.1",
         "mocha-suppress-logs": "^0.2.0",
         "nyc": "^15.1.0",
-        "prettier": "2.0.5",
-        "sinon": "^9.0.2"
+        "prettier": "^2.0.5",
+        "sinon": "^10.0.0"
       }
     },
     "node_modules/@azure/ms-rest-js": {
@@ -69,20 +69,20 @@
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+      "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.0",
+        "@babel/generator": "^7.14.3",
         "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helper-module-transforms": "^7.14.2",
         "@babel/helpers": "^7.14.0",
-        "@babel/parser": "^7.14.0",
+        "@babel/parser": "^7.14.3",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0",
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -117,12 +117,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
-      "integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.14.1",
+        "@babel/types": "^7.14.2",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -152,14 +152,14 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.2"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
@@ -190,9 +190,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
-      "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.13.12",
@@ -201,8 +201,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.14.0",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
@@ -215,15 +215,15 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "node_modules/@babel/helper-simple-access": {
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
-      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -382,17 +382,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
-      "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.0",
-        "@babel/helper-function-name": "^7.12.13",
+        "@babel/generator": "^7.14.2",
+        "@babel/helper-function-name": "^7.14.2",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.14.0",
-        "@babel/types": "^7.14.0",
+        "@babel/parser": "^7.14.2",
+        "@babel/types": "^7.14.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
@@ -416,9 +416,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
-      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.14.0",
@@ -769,18 +769,18 @@
       }
     },
     "node_modules/@types/mongodb": {
-      "version": "3.6.12",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
-      "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.15.tgz",
+      "integrity": "sha512-66o54Py66NyYxb9/za2dH01ZsD1PCbPdJeys1VMhlitE4lrbmF3akpICzVmzkaiL6byCeG8iClfhD5ThZGu8+A==",
       "dependencies": {
         "@types/bson": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA=="
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
+      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A=="
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
@@ -1160,17 +1160,17 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "node_modules/botbuilder": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.13.1.tgz",
-      "integrity": "sha512-fM+e9ENU1EgebGXIX2qqkIXDkd7c/lleNrqeKasdRteat+ohp3w0ZPSSFnavU7HzU/eYGFUALve1xIQmnmzS0A==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.13.4.tgz",
+      "integrity": "sha512-a9XwGU/pCa7KXeZ3p3RQB8aZmk+Vva63c6YhQmxpN9x0V/0ovWMJKcE0eDr/Kysj2n8Pm5SYasHZ+6Tm1GQhVA==",
       "dependencies": {
         "@azure/ms-rest-js": "1.9.1",
         "axios": "^0.21.1",
-        "botbuilder-core": "4.13.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
-        "botframework-streaming": "4.13.1",
+        "botbuilder-core": "4.13.4",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
+        "botframework-streaming": "4.13.4",
         "dayjs": "^1.10.3",
         "filenamify": "^4.1.0",
         "fs-extra": "^7.0.1",
@@ -1190,31 +1190,31 @@
       }
     },
     "node_modules/botbuilder-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.13.1.tgz",
-      "integrity": "sha512-oumP5gfJZJrHYGOIdu9LglbLPYbRXs5hkNz2jw+zsK2mjJB07teC/qp/nVqQKQDP+vsaerK8FmpMIYpO78Fotg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.13.4.tgz",
+      "integrity": "sha512-gCY6tJpTa4jYYy5xOUeGT7aU8b79WXmuxYL+Uac7mRCLngvrAkWlN3ipPL61ghTfBAvoPCuZSvsnX3OkZsRYOQ==",
       "dependencies": {
         "assert": "^1.4.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
-        "botframework-schema": "4.13.1",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
+        "botframework-schema": "4.13.4",
         "uuid": "^8.3.2"
       }
     },
     "node_modules/botbuilder-dialogs": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.13.1.tgz",
-      "integrity": "sha512-/mASe02B6qW9vpz7VAdEcR7RlC78xOqd6edBeWu0lYTRBYuURbA+JxxIMlUkfmuwgnTQ2EcLtaiSGDYUjK2Nsg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.13.4.tgz",
+      "integrity": "sha512-0wSILiB1qT7+Pp/O/0fVFlDAquJRMQrmVnLd3IuxWMfCadTx1BeEqFmdvq9XG2CMEyeeTFwaxhRe8sek84mMpg==",
       "dependencies": {
         "@microsoft/recognizers-text-choice": "1.1.4",
         "@microsoft/recognizers-text-date-time": "1.1.4",
         "@microsoft/recognizers-text-number": "1.1.4",
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "botbuilder-core": "4.13.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
+        "botbuilder-core": "4.13.4",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
         "globalize": "^1.4.2",
         "lodash": "^4.17.21",
         "runtypes": "~5.1.0",
@@ -1222,52 +1222,52 @@
       }
     },
     "node_modules/botbuilder-dialogs-adaptive-runtime-core": {
-      "version": "4.13.1-preview",
-      "resolved": "https://registry.npmjs.org/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.1-preview.tgz",
-      "integrity": "sha512-69qdJ6Pj1Scu2uowOLfUeb7/0bT4naoAxJQN25qPADOBrhWO98hSJPsQxNAe2b0z7GSM40QwnydIK8FQ4jmD7w==",
+      "version": "4.13.4-preview",
+      "resolved": "https://registry.npmjs.org/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.4-preview.tgz",
+      "integrity": "sha512-jEAuHVk+NTwmYXMvaZDinz5w5cuYcFau+bebUhDLNKhsBNqHf5Kst431QHEPtqN/eleXnc+HEvXJ3IFBk0EjCA==",
       "dependencies": {
         "dependency-graph": "^0.10.0",
         "runtypes": "~5.1.0"
       }
     },
     "node_modules/botbuilder-stdlib": {
-      "version": "4.13.1-internal",
-      "resolved": "https://registry.npmjs.org/botbuilder-stdlib/-/botbuilder-stdlib-4.13.1-internal.tgz",
-      "integrity": "sha512-olwY7JWQy7JZ3CtW4Z7mxImDMe7yXAF1Ut++OWQ6PKPvx/9C8FsKrAc+M41QqF1y2yriSkHbaadsQqHqPP9fVw=="
+      "version": "4.13.4-internal",
+      "resolved": "https://registry.npmjs.org/botbuilder-stdlib/-/botbuilder-stdlib-4.13.4-internal.tgz",
+      "integrity": "sha512-aoKolMHw6Gicaz/ks6CjzMqgHx4JeeJbJyzhQR/CCOMFFxriwvmuKbIGyvD41nKL4wqMvbFxfWSliWs+pRpTpQ=="
     },
     "node_modules/botframework-connector": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.13.1.tgz",
-      "integrity": "sha512-o6H2gAE1AX0t4VbGGEE6bIf8PzGMRRHjAZ7U+BcKH1YtsMm/4OADaUmsKDKDqNpowbAMeN7lAKdKtQR3pRoY3w==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.13.4.tgz",
+      "integrity": "sha512-c7OujavEc/HAW2i94V/VUS3Y/xIrmZE9LoXQg1OMJEsWI8T4PfqbiPE+QnS6BB2sxY1fY/AgpWoTllaXvbVpjQ==",
       "dependencies": {
         "@azure/ms-rest-js": "1.9.1",
         "@types/jsonwebtoken": "7.2.8",
         "@types/node": "^10.17.27",
         "adal-node": "0.2.1",
         "base64url": "^3.0.0",
-        "botframework-schema": "4.13.1",
+        "botframework-schema": "4.13.4",
         "cross-fetch": "^3.0.5",
         "jsonwebtoken": "8.0.1",
         "rsa-pem-from-mod-exp": "^0.8.4"
       }
     },
     "node_modules/botframework-connector/node_modules/@types/node": {
-      "version": "10.17.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-      "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/botframework-schema": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.13.1.tgz",
-      "integrity": "sha512-UP9UVSPk0TxCWnk7hHp1CpglyHkt28MlkIsDgVkVUyABDEOSMmReTQRhK9uZuP8vRFDArnUSU2rN44ykDxAtbg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.13.4.tgz",
+      "integrity": "sha512-zYRIcMdLIPMhT1f1Xek12s2IMW30KDzkEDw8k0E3ac7A+amkDvv61QahcGIVxyWoWyCTL3D28DgfM3Xmqv8NsA==",
       "dependencies": {
-        "botbuilder-stdlib": "4.13.1-internal"
+        "botbuilder-stdlib": "4.13.4-internal"
       }
     },
     "node_modules/botframework-streaming": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.13.1.tgz",
-      "integrity": "sha512-fMdUfDg/nrMQU40Dl6zAGbcC3dZMVMywUwVgKLGbGqpyqz9x+SDGRKGL4uo4vG36qM/4GdOdUuFFugY8IGSqTw==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.13.4.tgz",
+      "integrity": "sha512-KwhApm7wlBf2A+9RDI9DsrxqAyJhUXTtlZvSni0cxh0xj1CFGmF3ErKRHC11An5SXDFQk2N/idDVL5oCguth0A==",
       "dependencies": {
         "@types/node": "^10.17.27",
         "@types/ws": "^6.0.3",
@@ -1276,9 +1276,9 @@
       }
     },
     "node_modules/botframework-streaming/node_modules/@types/node": {
-      "version": "10.17.59",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-      "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
     },
     "node_modules/botkit": {
       "version": "4.10.0",
@@ -1403,10 +1403,14 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001223",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz",
-      "integrity": "sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==",
-      "dev": true
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -1844,12 +1848,12 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "dependencies": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       },
       "funding": {
@@ -1895,9 +1899,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.0.tgz",
-      "integrity": "sha512-yy3x9XjojW8ROTBePD25AcMoHqGHsvHmtfw8QWlpEXyMMXXPj6brUA464AptUvHuTPRmNz6Sd3ZLNLeJl6dHJA==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg==",
       "engines": {
         "node": ">=10"
       }
@@ -1925,9 +1929,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.727",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "version": "1.3.735",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.735.tgz",
+      "integrity": "sha512-cp7MWzC3NseUJV2FJFgaiesdrS+A8ZUjX5fLAxdRlcaPDkaPGFplX930S5vf84yqDp4LjuLdKouWuVOTwUfqHQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2002,13 +2006,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2056,18 +2060,15 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
-      "dependencies": {
-        "get-stdin": "^6.0.0"
-      },
       "bin": {
-        "eslint-config-prettier-check": "bin/cli.js"
+        "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
-        "eslint": ">=3.14.1"
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -2489,9 +2490,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
       "funding": [
         {
           "type": "individual",
@@ -2650,15 +2651,6 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/getpass": {
@@ -3726,14 +3718,14 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
-      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.7.tgz",
+      "integrity": "sha512-VXW2bWz47LhAEw0qs8Mk2zRgQwgbXH16KAwQFtylBu0zXO8rkQmA8ncsYbmICaVutZeINRlXYXG3MDIz90NM3g==",
       "dependencies": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.2",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       },
@@ -3899,9 +3891,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -4428,9 +4420,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -4878,16 +4870,16 @@
       }
     },
     "node_modules/sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "funding": {
@@ -5099,9 +5091,9 @@
       }
     },
     "node_modules/table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -5116,9 +5108,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
-      "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+      "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -5815,20 +5807,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
-      "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+      "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.0",
+        "@babel/generator": "^7.14.3",
         "@babel/helper-compilation-targets": "^7.13.16",
-        "@babel/helper-module-transforms": "^7.14.0",
+        "@babel/helper-module-transforms": "^7.14.2",
         "@babel/helpers": "^7.14.0",
-        "@babel/parser": "^7.14.0",
+        "@babel/parser": "^7.14.3",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0",
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -5855,12 +5847,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
-      "integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+      "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.14.1",
+        "@babel/types": "^7.14.2",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
@@ -5886,14 +5878,14 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-      "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+      "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
       "dev": true,
       "requires": {
         "@babel/helper-get-function-arity": "^7.12.13",
         "@babel/template": "^7.12.13",
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/helper-get-function-arity": {
@@ -5924,9 +5916,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
-      "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+      "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.13.12",
@@ -5935,8 +5927,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.14.0",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.14.0",
-        "@babel/types": "^7.14.0"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -5949,15 +5941,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+      "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.14.2",
+        "@babel/types": "^7.14.2"
       }
     },
     "@babel/helper-simple-access": {
@@ -6071,9 +6063,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
-      "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
+      "version": "7.14.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+      "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
       "dev": true
     },
     "@babel/template": {
@@ -6099,17 +6091,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
-      "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+      "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.14.0",
-        "@babel/helper-function-name": "^7.12.13",
+        "@babel/generator": "^7.14.2",
+        "@babel/helper-function-name": "^7.14.2",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.14.0",
-        "@babel/types": "^7.14.0",
+        "@babel/parser": "^7.14.2",
+        "@babel/types": "^7.14.2",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -6132,9 +6124,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.14.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
-      "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+      "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.14.0",
@@ -6417,18 +6409,18 @@
       }
     },
     "@types/mongodb": {
-      "version": "3.6.12",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.12.tgz",
-      "integrity": "sha512-49aEzQD5VdHPxyd5dRyQdqEveAg9LanwrH8RQipnMuulwzKmODXIZRp0umtxi1eBUfEusRkoy8AVOMr+kVuFog==",
+      "version": "3.6.15",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.15.tgz",
+      "integrity": "sha512-66o54Py66NyYxb9/za2dH01ZsD1PCbPdJeys1VMhlitE4lrbmF3akpICzVmzkaiL6byCeG8iClfhD5ThZGu8+A==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "15.0.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.2.tgz",
-      "integrity": "sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA=="
+      "version": "15.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.6.0.tgz",
+      "integrity": "sha512-gCYSfQpy+LYhOFTKAeE8BkyGqaxmlFxe+n4DKM6DR0wzw/HISUE/hAmkC/KT8Sw5PCJblqg062b3z9gucv3k0A=="
     },
     "@types/retry": {
       "version": "0.12.0",
@@ -6740,17 +6732,17 @@
       }
     },
     "botbuilder": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.13.1.tgz",
-      "integrity": "sha512-fM+e9ENU1EgebGXIX2qqkIXDkd7c/lleNrqeKasdRteat+ohp3w0ZPSSFnavU7HzU/eYGFUALve1xIQmnmzS0A==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder/-/botbuilder-4.13.4.tgz",
+      "integrity": "sha512-a9XwGU/pCa7KXeZ3p3RQB8aZmk+Vva63c6YhQmxpN9x0V/0ovWMJKcE0eDr/Kysj2n8Pm5SYasHZ+6Tm1GQhVA==",
       "requires": {
         "@azure/ms-rest-js": "1.9.1",
         "axios": "^0.21.1",
-        "botbuilder-core": "4.13.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
-        "botframework-streaming": "4.13.1",
+        "botbuilder-core": "4.13.4",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
+        "botframework-streaming": "4.13.4",
         "dayjs": "^1.10.3",
         "filenamify": "^4.1.0",
         "fs-extra": "^7.0.1",
@@ -6770,31 +6762,31 @@
       }
     },
     "botbuilder-core": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.13.1.tgz",
-      "integrity": "sha512-oumP5gfJZJrHYGOIdu9LglbLPYbRXs5hkNz2jw+zsK2mjJB07teC/qp/nVqQKQDP+vsaerK8FmpMIYpO78Fotg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder-core/-/botbuilder-core-4.13.4.tgz",
+      "integrity": "sha512-gCY6tJpTa4jYYy5xOUeGT7aU8b79WXmuxYL+Uac7mRCLngvrAkWlN3ipPL61ghTfBAvoPCuZSvsnX3OkZsRYOQ==",
       "requires": {
         "assert": "^1.4.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
-        "botframework-schema": "4.13.1",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
+        "botframework-schema": "4.13.4",
         "uuid": "^8.3.2"
       }
     },
     "botbuilder-dialogs": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.13.1.tgz",
-      "integrity": "sha512-/mASe02B6qW9vpz7VAdEcR7RlC78xOqd6edBeWu0lYTRBYuURbA+JxxIMlUkfmuwgnTQ2EcLtaiSGDYUjK2Nsg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botbuilder-dialogs/-/botbuilder-dialogs-4.13.4.tgz",
+      "integrity": "sha512-0wSILiB1qT7+Pp/O/0fVFlDAquJRMQrmVnLd3IuxWMfCadTx1BeEqFmdvq9XG2CMEyeeTFwaxhRe8sek84mMpg==",
       "requires": {
         "@microsoft/recognizers-text-choice": "1.1.4",
         "@microsoft/recognizers-text-date-time": "1.1.4",
         "@microsoft/recognizers-text-number": "1.1.4",
         "@microsoft/recognizers-text-suite": "1.1.4",
-        "botbuilder-core": "4.13.1",
-        "botbuilder-dialogs-adaptive-runtime-core": "4.13.1-preview",
-        "botbuilder-stdlib": "4.13.1-internal",
-        "botframework-connector": "4.13.1",
+        "botbuilder-core": "4.13.4",
+        "botbuilder-dialogs-adaptive-runtime-core": "4.13.4-preview",
+        "botbuilder-stdlib": "4.13.4-internal",
+        "botframework-connector": "4.13.4",
         "globalize": "^1.4.2",
         "lodash": "^4.17.21",
         "runtypes": "~5.1.0",
@@ -6802,54 +6794,54 @@
       }
     },
     "botbuilder-dialogs-adaptive-runtime-core": {
-      "version": "4.13.1-preview",
-      "resolved": "https://registry.npmjs.org/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.1-preview.tgz",
-      "integrity": "sha512-69qdJ6Pj1Scu2uowOLfUeb7/0bT4naoAxJQN25qPADOBrhWO98hSJPsQxNAe2b0z7GSM40QwnydIK8FQ4jmD7w==",
+      "version": "4.13.4-preview",
+      "resolved": "https://registry.npmjs.org/botbuilder-dialogs-adaptive-runtime-core/-/botbuilder-dialogs-adaptive-runtime-core-4.13.4-preview.tgz",
+      "integrity": "sha512-jEAuHVk+NTwmYXMvaZDinz5w5cuYcFau+bebUhDLNKhsBNqHf5Kst431QHEPtqN/eleXnc+HEvXJ3IFBk0EjCA==",
       "requires": {
         "dependency-graph": "^0.10.0",
         "runtypes": "~5.1.0"
       }
     },
     "botbuilder-stdlib": {
-      "version": "4.13.1-internal",
-      "resolved": "https://registry.npmjs.org/botbuilder-stdlib/-/botbuilder-stdlib-4.13.1-internal.tgz",
-      "integrity": "sha512-olwY7JWQy7JZ3CtW4Z7mxImDMe7yXAF1Ut++OWQ6PKPvx/9C8FsKrAc+M41QqF1y2yriSkHbaadsQqHqPP9fVw=="
+      "version": "4.13.4-internal",
+      "resolved": "https://registry.npmjs.org/botbuilder-stdlib/-/botbuilder-stdlib-4.13.4-internal.tgz",
+      "integrity": "sha512-aoKolMHw6Gicaz/ks6CjzMqgHx4JeeJbJyzhQR/CCOMFFxriwvmuKbIGyvD41nKL4wqMvbFxfWSliWs+pRpTpQ=="
     },
     "botframework-connector": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.13.1.tgz",
-      "integrity": "sha512-o6H2gAE1AX0t4VbGGEE6bIf8PzGMRRHjAZ7U+BcKH1YtsMm/4OADaUmsKDKDqNpowbAMeN7lAKdKtQR3pRoY3w==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-connector/-/botframework-connector-4.13.4.tgz",
+      "integrity": "sha512-c7OujavEc/HAW2i94V/VUS3Y/xIrmZE9LoXQg1OMJEsWI8T4PfqbiPE+QnS6BB2sxY1fY/AgpWoTllaXvbVpjQ==",
       "requires": {
         "@azure/ms-rest-js": "1.9.1",
         "@types/jsonwebtoken": "7.2.8",
         "@types/node": "^10.17.27",
         "adal-node": "0.2.1",
         "base64url": "^3.0.0",
-        "botframework-schema": "4.13.1",
+        "botframework-schema": "4.13.4",
         "cross-fetch": "^3.0.5",
         "jsonwebtoken": "8.0.1",
         "rsa-pem-from-mod-exp": "^0.8.4"
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         }
       }
     },
     "botframework-schema": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.13.1.tgz",
-      "integrity": "sha512-UP9UVSPk0TxCWnk7hHp1CpglyHkt28MlkIsDgVkVUyABDEOSMmReTQRhK9uZuP8vRFDArnUSU2rN44ykDxAtbg==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-schema/-/botframework-schema-4.13.4.tgz",
+      "integrity": "sha512-zYRIcMdLIPMhT1f1Xek12s2IMW30KDzkEDw8k0E3ac7A+amkDvv61QahcGIVxyWoWyCTL3D28DgfM3Xmqv8NsA==",
       "requires": {
-        "botbuilder-stdlib": "4.13.1-internal"
+        "botbuilder-stdlib": "4.13.4-internal"
       }
     },
     "botframework-streaming": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.13.1.tgz",
-      "integrity": "sha512-fMdUfDg/nrMQU40Dl6zAGbcC3dZMVMywUwVgKLGbGqpyqz9x+SDGRKGL4uo4vG36qM/4GdOdUuFFugY8IGSqTw==",
+      "version": "4.13.4",
+      "resolved": "https://registry.npmjs.org/botframework-streaming/-/botframework-streaming-4.13.4.tgz",
+      "integrity": "sha512-KwhApm7wlBf2A+9RDI9DsrxqAyJhUXTtlZvSni0cxh0xj1CFGmF3ErKRHC11An5SXDFQk2N/idDVL5oCguth0A==",
       "requires": {
         "@types/node": "^10.17.27",
         "@types/ws": "^6.0.3",
@@ -6858,9 +6850,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.59",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.59.tgz",
-          "integrity": "sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg=="
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
         }
       }
     },
@@ -6959,9 +6951,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001223",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz",
-      "integrity": "sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==",
+      "version": "1.0.30001228",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
+      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
       "dev": true
     },
     "caseless": {
@@ -7310,12 +7302,12 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-      "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
       "requires": {
         "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
+        "domhandler": "^4.2.0",
         "entities": "^2.0.0"
       }
     },
@@ -7343,9 +7335,9 @@
       }
     },
     "dotenv": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.0.tgz",
-      "integrity": "sha512-yy3x9XjojW8ROTBePD25AcMoHqGHsvHmtfw8QWlpEXyMMXXPj6brUA464AptUvHuTPRmNz6Sd3ZLNLeJl6dHJA=="
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
+      "integrity": "sha512-I9OvvrHp4pIARv4+x9iuewrWycX6CcZtoAu1XrzPxc5UygMJXJZYmBsynku8IkrJwgypE5DGNjDPmPRhDCptUg=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -7370,9 +7362,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.727",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-      "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+      "version": "1.3.735",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.735.tgz",
+      "integrity": "sha512-cp7MWzC3NseUJV2FJFgaiesdrS+A8ZUjX5fLAxdRlcaPDkaPGFplX930S5vf84yqDp4LjuLdKouWuVOTwUfqHQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -7429,13 +7421,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-      "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.26.0.tgz",
+      "integrity": "sha512-4R1ieRf52/izcZE7AlLy56uIHHDLT74Yzz2Iv2l6kDaYvEu9x+wMB5dZArVL8SYGXSYV2YAg70FcW5Y5nGGNIg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
-        "@eslint/eslintrc": "^0.4.0",
+        "@eslint/eslintrc": "^0.4.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -7474,13 +7466,11 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
       "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "3.4.0",
@@ -7810,9 +7800,9 @@
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "follow-redirects": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.0.tgz",
-      "integrity": "sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -7906,12 +7896,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
     },
     "getpass": {
@@ -8757,14 +8741,14 @@
       }
     },
     "mongodb": {
-      "version": "3.6.6",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz",
-      "integrity": "sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==",
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.7.tgz",
+      "integrity": "sha512-VXW2bWz47LhAEw0qs8Mk2zRgQwgbXH16KAwQFtylBu0zXO8rkQmA8ncsYbmICaVutZeINRlXYXG3MDIz90NM3g==",
       "requires": {
         "bl": "^2.2.1",
         "bson": "^1.1.4",
         "denque": "^1.4.1",
-        "optional-require": "^1.0.2",
+        "optional-require": "^1.0.3",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
       }
@@ -8888,9 +8872,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.71",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-      "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "version": "1.1.72",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+      "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
       "dev": true
     },
     "normalize-path": {
@@ -9291,9 +9275,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-      "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
+      "integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -9650,16 +9634,16 @@
       }
     },
     "sinon": {
-      "version": "9.2.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
-      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.1",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/samsam": "^5.3.1",
         "diff": "^4.0.2",
-        "nise": "^4.0.4",
+        "nise": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -9823,9 +9807,9 @@
       }
     },
     "table": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.7.0.tgz",
-      "integrity": "sha512-SAM+5p6V99gYiiy2gT5ArdzgM1dLDed0nkrWmG6Fry/bUS/m9x83BwpJUOf1Qj/x2qJd+thL6IkIx7qPGRxqBw==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+      "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -9837,9 +9821,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
-          "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+          "version": "8.5.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.5.0.tgz",
+          "integrity": "sha512-Y2l399Tt1AguU3BPRP9Fn4eN+Or+StUGWCUpbnFyXSo8NZ9S4uj+AG2pjs5apK+ZMOwYOz1+a+VKvKH7CudXgQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "chance": "^1.1.6",
     "codecov": "^3.8.1",
     "eslint": "^7.2.0",
-    "eslint-config-prettier": "^6.11.0",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-prettier": "^3.1.4",
     "mocha": "^8.0.1",
     "mocha-suppress-logs": "^0.2.0",
     "nyc": "^15.1.0",
-    "prettier": "2.0.5",
-    "sinon": "^9.0.2"
+    "prettier": "^2.0.5",
+    "sinon": "^10.0.0"
   }
 }

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -616,8 +616,7 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text:
-                "Your `1` :fistbump: has been sent. You have `5` left to give today.",
+              text: "Your `1` :fistbump: has been sent. You have `5` left to give today.",
             },
           },
         ],
@@ -648,8 +647,7 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text:
-                "Your `2` :fistbump: have been sent. You have `5` left to give today.",
+              text: "Your `2` :fistbump: have been sent. You have `5` left to give today.",
             },
           },
         ],
@@ -683,8 +681,7 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text:
-                "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `5`\n>>>Test Message",
+              text: "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `5`\n>>>Test Message",
             },
           },
         ],
@@ -720,16 +717,14 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text:
-                "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `1`\n>>>Test Message",
+              text: "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `1`\n>>>Test Message",
             },
           },
           {
             type: "section",
             text: {
               type: "mrkdwn",
-              text:
-                "I noticed this is your first time receiving a :fistbump:. Check out <https://liatrio.atlassian.net/wiki/spaces/LE/pages/817857117/Redeeming+Fistbumps|Confluence> to see what they can be used for, or try running `<@gratibot> help` for more information about me.",
+              text: "I noticed this is your first time receiving a :fistbump:. Check out <https://liatrio.atlassian.net/wiki/spaces/LE/pages/817857117/Redeeming+Fistbumps|Confluence> to see what they can be used for, or try running `<@gratibot> help` for more information about me.",
             },
           },
         ],


### PR DESCRIPTION
Updates several decencies as referenced by Dependabot. Most changes are minor or patch version changes.

Highlighting major version changes and any relevant effects on repo:
- eslint-config-prettier - Changes some linting rules, some formatting changes in tests correspond with this update.
- sinon - Drops support for older browsers, no effect for Gratibot