### PR TITLE
Socket Mode

### DIFF
--- a/.github/workflows/nonprod.yaml
+++ b/.github/workflows/nonprod.yaml
@@ -53,6 +53,6 @@ jobs:
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}
           TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
           TF_VAR_environment: "nonprod"
-          TF_VAR_signing_secret: ${{ secrets.NONPROD_SIGNING_SECRET }}
+          TF_VAR_app_token: ${{ secrets.NONPROD_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.NONPROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":oof:"

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -51,7 +51,7 @@ jobs:
           TF_VAR_instance_capacity: "2"
           TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
           TF_VAR_environment: "prod"
-          TF_VAR_signing_secret: ${{ secrets.PROD_PLAN_SIGNING_SECRET }}
+          TF_VAR_app_token: ${{ secrets.PROD_PLAN_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.PROD_PLAN_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":fistbump:"
   apply:
@@ -78,6 +78,6 @@ jobs:
           TF_VAR_instance_capacity: "2"
           TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
           TF_VAR_environment: "prod"
-          TF_VAR_signing_secret: ${{ secrets.PROD_SIGNING_SECRET }}
+          TF_VAR_app_token: ${{ secrets.PROD_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.PROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":fistbump:"

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -50,7 +50,7 @@ jobs:
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}
           TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
           TF_VAR_environment: "nonprod"
-          TF_VAR_signing_secret: ${{ secrets.NONPROD_SIGNING_SECRET }}
+          TF_VAR_app_token: ${{ secrets.NONPROD_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.NONPROD_BOT_TOKEN }}
   plan:
     name: "Terraform Nonprod plan"
@@ -76,7 +76,7 @@ jobs:
           TF_VAR_acr_subscription_id: ${{ secrets.AZURE_NONPROD_SUBSCRIPTION_ID }}
           TF_VAR_gratibot_image: "${{ env.IMAGE_NAME }}:${{ needs.build.outputs.docker_tag }}"
           TF_VAR_environment: "nonprod"
-          TF_VAR_signing_secret: ${{ secrets.NONPROD_SIGNING_SECRET }}
+          TF_VAR_app_token: ${{ secrets.NONPROD_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.NONPROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":oof:"
 

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ Create a Slack app for running a development version of Gratibot:
 1. On the **Basic Information** tab under *Settings*, scroll down to
 'App-Level Tokens' and click the button to 'Generate Token and Scopes'.
 Name your token 'websocket-token', and add the
-scope 'connections:write'. Generate the token, and save the value for later.
+scope 'connections:write'. Generate the token. Copy the ***Token*** that is
+generated, we'll use it later for the bot's APP_TOKEN.
 2. Go to the **Install App** tab under *Settings*. Click the button to
 install the app to your workspace, and follow the provided prompts. After
-installing,Copy the ***Bot User OAuth Token*** value, and save it for later.
+installing, copy the ***Bot User OAuth Token*** value, and save it for later.
 4. In your cloned copy of the repo, create a file called `.env`, it should look
 something like:
     ```

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Create a Slack app for running a development version of Gratibot:
 3. Select the Slack workspace you'll run the bot in for development.
 4. Copy Gratibot's app manifest from `slack_app_manifest.yml`.
 5. Replace any occurences of `${botName}` with a name for your bot.
-    - If you're developing in a shared workspace, consider a name like `YOUR_NAME-Gratibot`.
+    - If you're developing in a shared workspace, consider a name like `YOUR_NAME-gratibot`.
     This will help others to identify who owns the bot.
 6. Finally, confirm that the configuration looks correct and click 'Create'
 

--- a/README.md
+++ b/README.md
@@ -46,30 +46,27 @@ Create a Slack app for running a development version of Gratibot:
 ##### Create Your App
 
 1. Goto [api.slack.com/apps.](https://api.slack.com/apps)
-2. Click 'Create New App' and pick a name for your app.
-    - If you're developing in a shared workspace, consider a name like `${your_name}-bot`.
-    This will help others to identify who owns the bot.
+2. Click 'Create New App' and choose to create an app from an app manifest.
 3. Select the Slack workspace you'll run the bot in for development.
-4. Click the 'Create App' button.
+4. Copy Gratibot's app manifest from `slack_app_manifest.yml`.
+5. Replace any occurences of `${botName}` with a name for your bot.
+    - If you're developing in a shared workspace, consider a name like `YOUR_NAME-Gratibot`.
+    This will help others to identify who owns the bot.
+6. Finally, confirm that the configuration looks correct and click 'Create'
 
 ##### Run Your Local Copy
 
-1. Slack won't let you install the app without any permissions, so
-give your app a very basic permission so we have the ability to install it.
-We'll need to re-install the app later when we add new permission scopes.
-    1. On the sidebar, select the **OAuth & Permission** tab, under *Features*
-    2. On this tab, scroll to the 'Scopes'.
-    Add the 'Bot Token Scope', `app_mentions:read`.
-    3. Go to the tab **Install App** under *Settings*. Click through the
-    required prompts to install the app.
-2. On the **Basic Information** tab under *Settings*, find your
-'App Credentials'. Show the ***Signing Secret*** value, and save it for later.
-3. Return to the **Install App** tab. Copy the
-***Bot User OAuth Token*** value, and save it for later.
+1. On the **Basic Information** tab under *Settings*, scroll down to
+'App-Level Tokens' and click the button to 'Generate Token and Scopes'.
+Name your token 'websocket-token', and add the
+scope 'connections:write'. Generate the token, and save the value for later.
+2. Go to the **Install App** tab under *Settings*. Click the button to
+install the app to your workspace, and follow the provided prompts. After
+installing,Copy the ***Bot User OAuth Token*** value, and save it for later.
 4. In your cloned copy of the repo, create a file called `.env`, it should look
 something like:
     ```
-    SIGNING_SECRET=SECRET GOES HERE
+    APP_TOKEN=SECRET GOES HERE
     BOT_USER_OAUTH_ACCESS_TOKEN=SECRET GOES HERE
     ```
     Replace the values after the equals sign with the values you saved before.
@@ -78,45 +75,9 @@ something like:
 
 5. Now that your secrets are configured, run your local copy
 of Gratibot with `docker-compose up`
-6. Forward the local application to a public hostname with `ngrok http 3000`,
-be sure to note the hostname that ngrok generates as we'll need it later.
-
-##### Finishing Slack App Configuration
-
-1. Now that the bot is running, we can configure Slack to send specific
-events to it, which will then trigger bot actions. In the
-**Interactivity & Shortcuts** tab under *Features* enable 'Interactivity'
-and set the 'Request URL' to `https://${NGROK_HOSTNAME}/slack/events`
-2. On the **Event Subscriptions** tab under *Features* enable 'Events', and set
-the 'Request URL' to `https://${NGROK_HOSTNAME}/slack/events`
-3. On the same tab, we'll need to 'Subscribe to Bot Events'. Existing Gratibot
-functionality requires the following:
-    - `app_mention`
-    - `message.channels`
-    - `message.groups`
-    - `message.im`
-    - `message.mpim`
-    - `reaction_added`
-
-    If you're developing new functionality, you may need additional event
-    subscriptions.
-4. Return to the **OAuth & Permissions** tab, as we'll need to add a few more
-scopes to the app. Slack will automatically add scopes required for the events
-we subscribed to. In addition to those, we'll also need to add the following
-'Bot Token Scopes':
-    - `chat:write`
-    - `im:write`
-    - `users:read`
-
-    Once again, if you're developing new functionality, you may need additional
-    scopes to be granted.
-5. Reinstall the app by clicking the 'Reinstall to Workspace' 'button at the
-top of this tab. You'll need to reinstall the app any time you request
-additional scopes.
-
 
 With all of these steps complete, your bot should be running in the Slack
 workspace you chose to develop for. You should now be ready to test your bot,
 and progress with development.
 
-[Botkit Docs](https://botkit.ai/docs/v4)
+[Bolt Docs](https://slack.dev/bolt-js/concepts)

--- a/app.js
+++ b/app.js
@@ -3,7 +3,8 @@ const { App } = require("@slack/bolt");
 // Initializes your app with your bot token and signing secret
 const app = new App({
   token: process.env.BOT_USER_OAUTH_ACCESS_TOKEN,
-  signingSecret: process.env.SIGNING_SECRET,
+  socketMode: true,
+  appToken: process.env.APP_TOKEN,
 });
 
 var normalizedPath = require("path").join(__dirname, "features");

--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const { App } = require("@slack/bolt");
 
-// Initializes your app with your bot token and signing secret
 const app = new App({
   token: process.env.BOT_USER_OAUTH_ACCESS_TOKEN,
   socketMode: true,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,8 @@ services:
       - 3000:3000
     build: .
     environment:
-      - SIGNING_SECRET
       - BOT_USER_OAUTH_ACCESS_TOKEN
+      - APP_TOKEN
       - RECOGNIZE_EMOJI
       - REACTION_EMOJI
       - EXEMPT_USERS

--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -1,0 +1,36 @@
+_metadata:
+  major_version: 1
+  minor_version: 1
+display_information:
+  name: ${botName}
+  description: Recognize your peers for their awesome work!
+  background_color: "#458562"
+features:
+  bot_user:
+    display_name: ${botName}
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - app_mentions:read
+      - channels:history
+      - chat:write
+      - groups:history
+      - im:history
+      - mpim:history
+      - reactions:read
+      - users:read
+      - im:write
+settings:
+  event_subscriptions:
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.groups
+      - message.im
+      - message.mpim
+      - reaction_added
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true

--- a/tf/appservice.tf
+++ b/tf/appservice.tf
@@ -31,7 +31,7 @@ resource "azurerm_app_service" "gratibot_app_service" {
 
   app_settings = {
     "MONGO_URL"                   = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.mongo_connection_string.id})"
-    "SIGNING_SECRET"              = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.signing_secret.id})"
+    "APP_TOKEN"                   = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.app_token.id})"
     "BOT_USER_OAUTH_ACCESS_TOKEN" = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.bot_user_token.id})"
     "RECOGNIZE_EMOJI"             = var.gratibot_recognize_emoji
     "REACTION_EMOJI"              = var.gratibot_reaction_emoji

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -44,8 +44,8 @@ variable "gratibot_image" {
   type        = string
 }
 
-variable "signing_secret" {
-  description = "Signing secret for Slack app integration"
+variable "app_token" {
+  description = "App token for Slack app integration"
   type        = string
   sensitive   = true
 }

--- a/tf/vault.tf
+++ b/tf/vault.tf
@@ -35,9 +35,9 @@ resource "azurerm_key_vault_access_policy" "terraform_access" {
   ]
 }
 
-resource "azurerm_key_vault_secret" "signing_secret" {
-  name         = "signing-secret"
-  value        = var.signing_secret
+resource "azurerm_key_vault_secret" "app_token" {
+  name         = "app-token"
+  value        = var.app_token
   key_vault_id = azurerm_key_vault.gratibot.id
 
   depends_on = [


### PR DESCRIPTION
# Socket Mode

Sets up Gratibot to use socket mode based connections instead of HTTP delivered event payloads. This will speed up responses slightly, in addition to removing a need for a public endpoint for Gratibot, including for local development.

Because local development will no longer require ngrok, this PR also updates instructions for local dev, greatly simplifying getting started through use of an app manifest.

Long term we may want to use multiple app-manifests, or use a templated manifest to be able to generated different manifests for local, development, and production versions of Gratibot.

Socket mode drops the need for a signing secret to validate requests from Slack, however, a new App-Level token is required to form an initial websocket connection. In CD this app token replaces the signing secret. In addition app tokens have been generated and added to this repositories secrets. However, the existing signing secrets remain in GitHub, in case of a need to rollback.

**This PR requires corresponding changes to be made in the Slack App configuration to function with socket mode. Socket mode can not be enabled early without breaking existing bot, so the configuration changes and bot deployment will need to happen together.**