### PR TITLE
Add basic http respond to respond to Azure pings

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,13 @@
 const { App } = require("@slack/bolt");
+const express = require("express");
+
+const webserver = express();
+
+webserver.get("/", (req, res) => {
+  res.send("Gratibot is running!");
+});
+
+webserver.listen(process.env.PORT || 3000);
 
 const app = new App({
   token: process.env.BOT_USER_OAUTH_ACCESS_TOKEN,
@@ -15,7 +24,7 @@ require("fs")
 
 (async () => {
   // Start your app
-  await app.start(process.env.PORT || 3000);
+  await app.start();
 
   console.log("⚡️ Bolt app is running!");
 })();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@slack/bolt": "^3.4.0",
         "dotenv": "^10.0.0",
+        "express": "^4.17.1",
         "moment-timezone": "^0.5.31",
         "monk": "^7.3.1",
         "winston": "^3.3.3"
@@ -1407,6 +1408,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -3615,7 +3617,8 @@
         "bson": "^1.1.4",
         "denque": "^1.4.1",
         "optional-require": "^1.0.3",
-        "safe-buffer": "^5.1.2"
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       },
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@slack/bolt": "^3.4.0",
     "dotenv": "^10.0.0",
+    "express": "^4.17.1",
     "moment-timezone": "^0.5.31",
     "monk": "^7.3.1",
     "winston": "^3.3.3"


### PR DESCRIPTION
Azure App Service requires containers to respond to http pings to be consider healthy. Configuring Gratibot to use socket mode disabled its ability to respond to these pings and caused the service to be flagged as unhealthy.

Ideally we'd configure Gratibot with custom routes as part of the receiver package in Bolt, however, the SocketModeReceiver doesn't currently support custom routes. See: https://github.com/slackapi/bolt-js/issues/834

Until support is added (Milestone 3.5.0), this PR adds a basic express response to satisfy Azure's requirements. 