### PR TITLE
Add slack manifest disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Create a Slack app for running a development version of Gratibot:
 
 ##### Create Your App
 
+> When using Slack manifests you **cannot** use an old slack app. You will need to create a new one.
+
 1. Goto [api.slack.com/apps.](https://api.slack.com/apps)
 2. Click 'Create New App' and choose to create an app from an app manifest.
 3. Select the Slack workspace you'll run the bot in for development.


### PR DESCRIPTION
Add a new note that users need to use a new Slack app when creating apps with a manifest.