### PR TITLE
Issue 45 Indicate Reaction

### DIFF
--- a/features/recognize.js
+++ b/features/recognize.js
@@ -34,6 +34,7 @@ async function respondToRecognitionMessage({ message, client }) {
       trimmedMessage: recognition.trimmedGratitudeMessage(message.text),
       channel: message.channel,
       tags: recognition.gratitudeTagsIn(message.text),
+      type: recognizeEmoji,
     };
 
     await recognition.validateAndSendGratitude(gratitude);
@@ -83,8 +84,9 @@ async function respondToRecognitionReaction({ event, client }) {
       count: 1,
       message: originalMessage.text,
       trimmedMessage: recognition.trimmedGratitudeMessage(originalMessage.text),
-      channel: originalMessage.channel,
+      channel: event.channel,
       tags: recognition.gratitudeTagsIn(originalMessage.text),
+      type: reactionEmoji,
     };
     await recognition.validateAndSendGratitude(gratitude);
   } catch (e) {

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -182,7 +182,7 @@ async function receiverSlackNotification(gratitude, receiver) {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: `You just got recognized by <@${gratitude.giver.id}> in <#${gratitude.channel}>. You earned \`${gratitude.count}\` and your new balance is \`${receiverBalance}\`\n>>>${gratitude.message}`,
+      text: `You just got a ${gratitude.type} from <@${gratitude.giver.id}> in <#${gratitude.channel}>. You earned \`${gratitude.count}\` and your new balance is \`${receiverBalance}\`\n>>>${gratitude.message}`,
     },
   });
 
@@ -217,7 +217,8 @@ async function receiverSlackNotification(gratitude, receiver) {
  *   message: string,
  *   trimmedMessage: string,
  *   channel: string,
- *   tags [string],
+ *   tags: [string],
+ *   type: string,
  * }
  */
 module.exports = {

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -674,6 +674,7 @@ describe("service/recognition", () => {
         count: 1,
         channel: "TestChannel",
         message: "Test Message",
+        type: ":fistbump:",
       };
       const expectedResponse = {
         blocks: [
@@ -681,7 +682,7 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `5`\n>>>Test Message",
+              text: "You just got a :fistbump: from <@Giver> in <#TestChannel>. You earned `1` and your new balance is `5`\n>>>Test Message",
             },
           },
         ],
@@ -710,6 +711,7 @@ describe("service/recognition", () => {
         count: 1,
         channel: "TestChannel",
         message: "Test Message",
+        type: ":fistbump:",
       };
       const expectedResponse = {
         blocks: [
@@ -717,7 +719,7 @@ describe("service/recognition", () => {
             type: "section",
             text: {
               type: "mrkdwn",
-              text: "You just got recognized by <@Giver> in <#TestChannel>. You earned `1` and your new balance is `1`\n>>>Test Message",
+              text: "You just got a :fistbump: from <@Giver> in <#TestChannel>. You earned `1` and your new balance is `1`\n>>>Test Message",
             },
           },
           {


### PR DESCRIPTION
Adds a new 'type' field to gratitude object which denotes how the gratitude was triggered.
References type in notification message to denote to receiving users whether gratitude came from a message or from a reaction.

Also, fixes bug where reaction-based gratitude wouldn't correctly show the channel the message came from.