### PR TITLE
Manifest Updates

### DIFF
--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -6,6 +6,10 @@ display_information:
   description: Recognize your peers for their awesome work!
   background_color: "#458562"
 features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
   bot_user:
     display_name: ${botName}
     always_online: true


### PR DESCRIPTION
Enables sending direct messages to a newly initialized bot. Previously direct messages to a new bot were disabled, and seemed to be possible only after the bot sent its first direct message to the user.

This change won't affect deployed versions of Gratibot, which should already properly allowed direct messages, but this should make the development process slightly better.