### PR TITLE
Issue 148 Notification Balance Bug

### DIFF
--- a/service/recognition.js
+++ b/service/recognition.js
@@ -176,7 +176,8 @@ async function giverSlackNotification(gratitude) {
 }
 
 async function receiverSlackNotification(gratitude, receiver) {
-  const receiverBalance = await balance.lifetimeEarnings(receiver);
+  const lifetimeTotal = await balance.lifetimeEarnings(receiver);
+  const receiverBalance = await balance.currentBalance(receiver);
   let blocks = [];
   blocks.push({
     type: "section",
@@ -186,7 +187,7 @@ async function receiverSlackNotification(gratitude, receiver) {
     },
   });
 
-  if (gratitude.count == receiverBalance) {
+  if (gratitude.count == lifetimeTotal) {
     blocks.push({
       type: "section",
       text: {

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -660,7 +660,8 @@ describe("service/recognition", () => {
   });
   describe("receiverSlackNotification", () => {
     it("should generate a markdown response for recognition", async () => {
-      sinon.stub(balance, "lifetimeEarnings").resolves(5);
+      sinon.stub(balance, "lifetimeEarnings").resolves(100);
+      sinon.stub(balance, "currentBalance").resolves(5);
       const gratitude = {
         giver: {
           id: "Giver",
@@ -698,6 +699,7 @@ describe("service/recognition", () => {
 
     it("should include additional message for first time earners", async () => {
       sinon.stub(balance, "lifetimeEarnings").resolves(1);
+      sinon.stub(balance, "currentBalance").resolves(1);
       const gratitude = {
         giver: {
           id: "Giver",


### PR DESCRIPTION
Updates Gratibot notifications to display user balance. Previously a user's lifetime total was displayed by mistake, which didn't take into account any possible deductions.

Lifetime totals are still viewable via the 'balance' command, but after this change they will not be shown in the notification after receiving a fistbump.