### PR TITLE
use real timestamp for initial golden recognition

### DIFF
--- a/database/goldenRecognitionCollection.js
+++ b/database/goldenRecognitionCollection.js
@@ -17,7 +17,7 @@ async function initializeGoldenRecognitionCollection () {
     const collectionValues = {
       recognizer: initialGoldenRecognitionHolder,
       recognizee: initialGoldenRecognitionHolder,
-      timestamp: "2022-02-08T00:58:12.779Z",
+      timestamp: new Date(),
       message: "initial golden recognition",
       channel: "",
       values: [],

--- a/database/goldenRecognitionCollection.js
+++ b/database/goldenRecognitionCollection.js
@@ -17,7 +17,7 @@ async function initializeGoldenRecognitionCollection () {
     const collectionValues = {
       recognizer: initialGoldenRecognitionHolder,
       recognizee: initialGoldenRecognitionHolder,
-      timestamp: "",
+      timestamp: "2022-02-08T00:58:12.779Z",
       message: "initial golden recognition",
       channel: "",
       values: [],


### PR DESCRIPTION
Use real timestamp for initial golden recognition. Addresses issue seen in non prod where empty string was always considered the latest timestamp when sorted