### PR TITLE
change format of golden fistbump response string

### DIFF
--- a/config.js
+++ b/config.js
@@ -7,7 +7,8 @@ config.logLevel = process.env.LOG_LEVEL || "info";
 config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ":fistbump:";
 config.goldenRecognizeEmoji =
   process.env.GOLDEN_RECOGNIZE_EMOJI || ":goldenfistbump:";
-config.goldenRecognizeChannel = process.env.GOLDEN_RECOGNIZE_CHANNEL || "liatrio";
+config.goldenRecognizeChannel =
+  process.env.GOLDEN_RECOGNIZE_CHANNEL || "liatrio";
 config.reactionEmoji = process.env.REACTION_EMOJI || ":nail_care:";
 config.maximum = process.env.GRATIBOT_LIMIT || 5;
 config.minimumMessageLength = 20;

--- a/config.js
+++ b/config.js
@@ -7,7 +7,7 @@ config.logLevel = process.env.LOG_LEVEL || "info";
 config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ":fistbump:";
 config.goldenRecognizeEmoji =
   process.env.GOLDEN_RECOGNIZE_EMOJI || ":goldenfistbump:";
-config.goldenRecognizeChannel = "liatrio";
+config.goldenRecognizeChannel = process.env.GOLDEN_RECOGNIZE_CHANNEL || "liatrio";
 config.reactionEmoji = process.env.REACTION_EMOJI || ":nail_care:";
 config.maximum = process.env.GRATIBOT_LIMIT || 5;
 config.minimumMessageLength = 20;

--- a/features/golden-recognize.js
+++ b/features/golden-recognize.js
@@ -62,9 +62,7 @@ async function respondToRecognitionMessage({ message, client }) {
     //this call to postMessage sends a message to a separate public channel for everyone to see
     client.chat.postMessage({
       channel: config.goldenRecognizeChannel,
-      text: `The ${goldenRecognizeEmoji} has been bestowed upon thy majesty `,
-      ...`<@${gratitude.receivers[0].id}> by <@${gratitude.giver.id}> in <#${message.channel}>! :crown:  :tada:`,
-      ...`\n>${message.text}\n>`,
+      text: `The ${goldenRecognizeEmoji} has been bestowed upon thy majesty <@${gratitude.receivers[0].id}> by <@${gratitude.giver.id}> in <#${message.channel}>! :crown:  :tada:\n>${message.text}\n>`,
     }),
   ]);
 }


### PR DESCRIPTION
Fix format of text for golden fistbump alert messaging. Old format wasn't working as expected.