### PR TITLE
feat: Gratibot automatically adds the reaction emoji to messages

### DIFF
--- a/features/recognize.js
+++ b/features/recognize.js
@@ -73,6 +73,11 @@ async function respondToRecognitionMessage({ message, client }) {
       text: `${recognizeEmoji} has been sent.`,
       ...(await recognition.giverSlackNotification(gratitude)),
     }),
+    client.reactions.add({
+      channel: message.channel,
+      name: config.reactionEmoji.slice(1, -1),
+      timestamp: message.ts,
+    }),
   ]);
 }
 

--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -25,6 +25,7 @@ oauth_config:
       - im:history
       - mpim:history
       - reactions:read
+      - reactions:write
       - users:read
       - im:read
       - im:write


### PR DESCRIPTION
Updates Gratibot to automatically add the reaction emoji to valid fistbump messages to make it easier for others to join in.

In local testing it appeared that the reaction from Gratibot didn't trigger a 'reaction_added' event from Slack at all, so there should be no risk of users gaining an extra fistbump from the new reaction. However, even if such an event was sent, recognition from bots should be prevented during normal validation steps.

Closes #222.