### PR TITLE
ci: add workflow_dispatch with GRATIBOT_LIMIT input

### DIFF
--- a/.github/workflows/nonprod.yaml
+++ b/.github/workflows/nonprod.yaml
@@ -67,4 +67,4 @@ jobs:
           TF_VAR_bot_user_token: ${{ secrets.NONPROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":oof:"
           TF_VAR_gratibot_log_level: "debug"
-          GRATIBOT_LIMIT: ${{ inputs.gratibot_limit }}
+          TF_VAR_gratibot_limit: ${{ inputs.gratibot_limit }}

--- a/.github/workflows/nonprod.yaml
+++ b/.github/workflows/nonprod.yaml
@@ -6,6 +6,15 @@ on:
     paths-ignore:
       - "README.md"
       - "catalog.yaml"
+
+  workflow_dispatch:
+    inputs:
+      gratibot_limit:
+        description: "The amount of fistbumps that a user can give for one day."
+        required: false
+        default: "5"
+        type: string
+
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/gratibot
 
@@ -57,3 +66,4 @@ jobs:
           TF_VAR_bot_user_token: ${{ secrets.NONPROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":oof:"
           TF_VAR_gratibot_log_level: "debug"
+          GRATIBOT_LIMIT: ${{ inputs.gratibot_limit }}

--- a/.github/workflows/nonprod.yaml
+++ b/.github/workflows/nonprod.yaml
@@ -21,7 +21,7 @@ env:
 jobs:
   build:
     name: Build and Publish Image
-    if: github.event_name == push || contains(['Pactionly', 'gesparza3'], github.actor)
+    if: github.event_name == 'push' || contains(['Pactionly', 'gesparza3'], github.actor)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/nonprod.yaml
+++ b/.github/workflows/nonprod.yaml
@@ -21,6 +21,7 @@ env:
 jobs:
   build:
     name: Build and Publish Image
+    if: github.event_name == push || contains(['Pactionly', 'gesparza3'], github.actor)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Tag image
     runs-on: ubuntu-latest
-    if: github.event_name == push || contains(['Pactionly', 'gesparza3'], github.actor)
+    if: github.event_name == 'push' || contains(['Pactionly', 'gesparza3'], github.actor)
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -64,7 +64,7 @@ jobs:
           TF_VAR_app_token: ${{ secrets.PROD_PLAN_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.PROD_PLAN_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":fistbump:"
-          GRATIBOT_LIMIT: ${{ inputs.gratibot_limit }}
+          TF_VAR_gratibot_limit: ${{ inputs.gratibot_limit }}
   apply:
     name: "Terraform Prod Apply"
     runs-on: ubuntu-latest

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Tag image
     runs-on: ubuntu-latest
+    if: github.event_name == push || contains(['Pactionly', 'gesparza3'], github.actor)
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/prod.yaml
+++ b/.github/workflows/prod.yaml
@@ -3,6 +3,15 @@ on:
   push:
     tags:
       - v*.*.*
+
+  workflow_dispatch:
+    inputs:
+      gratibot_limit:
+        description: "The amount of fistbumps that a user can give for one day."
+        required: false
+        default: "5"
+        type: string
+
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/gratibot
 
@@ -54,6 +63,7 @@ jobs:
           TF_VAR_app_token: ${{ secrets.PROD_PLAN_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.PROD_PLAN_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":fistbump:"
+          GRATIBOT_LIMIT: ${{ inputs.gratibot_limit }}
   apply:
     name: "Terraform Prod Apply"
     runs-on: ubuntu-latest
@@ -81,3 +91,4 @@ jobs:
           TF_VAR_app_token: ${{ secrets.PROD_APP_TOKEN }}
           TF_VAR_bot_user_token: ${{ secrets.PROD_BOT_TOKEN }}
           TF_VAR_gratibot_recognize_emoji: ":fistbump:"
+          GRATIBOT_LIMIT: ${{ inputs.gratibot_limit }}

--- a/tf/appservice.tf
+++ b/tf/appservice.tf
@@ -37,5 +37,6 @@ resource "azurerm_app_service" "gratibot_app_service" {
     "RECOGNIZE_EMOJI"             = var.gratibot_recognize_emoji
     "REACTION_EMOJI"              = var.gratibot_reaction_emoji
     "LOG_LEVEL"                   = var.gratibot_log_level
+    "GRATIBOT_LIMIT"              = var.gratibot_limit
   }
 }

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -73,3 +73,9 @@ variable "gratibot_log_level" {
   type        = string
   default     = "info"
 }
+
+variable "gratibot_limit" {
+  description = "The limit of fistbumps one person can give in a single day."
+  type        = string
+  default     = "5"
+}


### PR DESCRIPTION
Closes #238 by adding a `workflow_dispatch` rule for the GitHub Action. The GitHub Action workflow will now take an input from the user to set the env variable of `GRATIBOT_LIMIT`. This env variable is what sets the amount of fistbumps that a user can give out in a day.
