### PR TITLE
chore: bump node version to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.14.0-alpine3.10
+FROM node:18.7-alpine3.15
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
Closes #235 by bumping the node version in the Dockerfile to 18.7.

An example bot is on the workspace as `@christ-gratibot-v2`. Let me know if there are any issues that I didn't see with testing.