### PR TITLE
update regex for multiplier

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,11 @@
 var config = {};
+var _ = require("lodash");
 
 config.mongo_url = process.env.MONGO_URL || "mongodb://mongodb:27017/gratibot";
 
 config.logLevel = process.env.LOG_LEVEL || "info";
 
-config.recognizeEmoji = process.env.RECOGNIZE_EMOJI || ":fistbump:";
+config.recognizeEmoji = _.escapeRegExp(process.env.RECOGNIZE_EMOJI) || ":fistbump:";
 config.goldenRecognizeEmoji =
   process.env.GOLDEN_RECOGNIZE_EMOJI || ":goldenfistbump:";
 config.goldenRecognizeChannel =

--- a/config.js
+++ b/config.js
@@ -5,7 +5,8 @@ config.mongo_url = process.env.MONGO_URL || "mongodb://mongodb:27017/gratibot";
 
 config.logLevel = process.env.LOG_LEVEL || "info";
 
-config.recognizeEmoji = _.escapeRegExp(process.env.RECOGNIZE_EMOJI) || ":fistbump:";
+config.recognizeEmoji =
+  _.escapeRegExp(process.env.RECOGNIZE_EMOJI) || ":fistbump:";
 config.goldenRecognizeEmoji =
   process.env.GOLDEN_RECOGNIZE_EMOJI || ":goldenfistbump:";
 config.goldenRecognizeChannel =

--- a/features/help.js
+++ b/features/help.js
@@ -41,6 +41,13 @@ The more emojis you add, the more recognition they get!
 
 > @alice just pushed the cleanest code I've ever seen! ${recognizeEmoji} ${recognizeEmoji} ${recognizeEmoji}
 
+Use multipliers to give more recognition!
+
+> @alice presented an amazing demo at a conference! ${recognizeEmoji} x2
+
+or
+
+> @alice presented an amazing demo at a conference! x2 ${recognizeEmoji}
 
 If someone else has given a ${recognizeEmoji} to someone, and you'd like to \
 give one of your own for the same reason, you can react to the message with \

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -19,7 +19,7 @@ const groupRegex = /<!subteam\^([a-zA-Z0-9]+)\|@([a-zA-Z0-9]+)>/g;
 const tagRegex = /#(\S+)/g;
 const generalEmojiRegex = /:([a-z-_']+):/g;
 const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
-const multiplierRegex = /\:fistbump\:\sx([0-9]+)|x([0-9]+)\s\:fistbump\:/;
+const multiplierRegex = /:fistbump:\sx([0-9]+)|x([0-9]+)\s:fistbump:/;
 
 // TODO Can we add a 'count' field to the recognition?
 async function giveRecognition(

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -19,7 +19,7 @@ const groupRegex = /<!subteam\^([a-zA-Z0-9]+)\|@([a-zA-Z0-9]+)>/g;
 const tagRegex = /#(\S+)/g;
 const generalEmojiRegex = /:([a-z-_']+):/g;
 const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
-const multiplierRegex = /x([0-9]+)/;
+const multiplierRegex = /\:fistbump\:\sx([0-9]+)|x([0-9]+)\s\:fistbump\:/;
 
 // TODO Can we add a 'count' field to the recognition?
 async function giveRecognition(
@@ -183,8 +183,9 @@ async function gratitudeReceiverIdsIn(client, text) {
 
 function gratitudeCountIn(text) {
   const emojiCount = (text.match(gratitudeEmojiRegex) || []).length;
-  const multiplier = text.match(multiplierRegex)
-    ? text.match(multiplierRegex)[1]
+  const multiplierFinding = text.match(multiplierRegex) ? text.match(multiplierRegex).filter(Boolean): null
+  const multiplier = multiplierFinding
+    ? multiplierFinding[1]
     : 1;
   return emojiCount * multiplier;
 }

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -19,7 +19,9 @@ const groupRegex = /<!subteam\^([a-zA-Z0-9]+)\|@([a-zA-Z0-9]+)>/g;
 const tagRegex = /#(\S+)/g;
 const generalEmojiRegex = /:([a-z-_']+):/g;
 const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
-const multiplierRegex = /:fistbump:\sx([0-9]+)|x([0-9]+)\s:fistbump:/;
+const multiplierRegex = new RegExp(
+  `${config.recognizeEmoji}\\sx([0-9]+)|x([0-9]+)\\s${config.recognizeEmoji}`
+);
 
 // TODO Can we add a 'count' field to the recognition?
 async function giveRecognition(
@@ -183,10 +185,10 @@ async function gratitudeReceiverIdsIn(client, text) {
 
 function gratitudeCountIn(text) {
   const emojiCount = (text.match(gratitudeEmojiRegex) || []).length;
-  const multiplierFinding = text.match(multiplierRegex) ? text.match(multiplierRegex).filter(Boolean): null
-  const multiplier = multiplierFinding
-    ? multiplierFinding[1]
-    : 1;
+  const multiplierFinding = text.match(multiplierRegex)
+    ? text.match(multiplierRegex).filter(Boolean)
+    : null;
+  const multiplier = multiplierFinding ? multiplierFinding[1] : 1;
   return emojiCount * multiplier;
 }
 

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -447,7 +447,33 @@ describe("service/recognition", () => {
       const result = recognition.gratitudeCountIn(text);
       expect(result).to.equal(1);
     });
+
+    it("should use the multiplier found after the fistbump", async () => {
+      const text = "x4ce level work :fistbump: x5 <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(5);
+    });
+
+    it("should use the multiplier found before the fistbump", async () => {
+      const text = "x4ce level work x5 :fistbump: <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(5);
+    });
+
+    it("should use the multiplier found before the fistbump even with more than 3 x findings", async () => {
+      const text = "x4ce level work x5 :fistbump: <@TestUser> Test Message lets x8 the building";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(5);
+    });
+
+    it("should use the multiplier found before the fistbump even if there is a following multiplier", async () => {
+      const text = "x4ce level work x5 :fistbump: x3 <@TestUser> Test Message";
+      const result = recognition.gratitudeCountIn(text);
+      expect(result).to.equal(5);
+    });
+
   });
+  
 
   describe("gratitudeTagsIn", () => {
     it("should find a tag in message", async () => {

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -461,7 +461,8 @@ describe("service/recognition", () => {
     });
 
     it("should use the multiplier found before the fistbump even with more than 3 x findings", async () => {
-      const text = "x4ce level work x5 :fistbump: <@TestUser> Test Message lets x8 the building";
+      const text =
+        "x4ce level work x5 :fistbump: <@TestUser> Test Message lets x8 the building";
       const result = recognition.gratitudeCountIn(text);
       expect(result).to.equal(5);
     });
@@ -471,9 +472,7 @@ describe("service/recognition", () => {
       const result = recognition.gratitudeCountIn(text);
       expect(result).to.equal(5);
     });
-
   });
-  
 
   describe("gratitudeTagsIn", () => {
     it("should find a tag in message", async () => {


### PR DESCRIPTION
The regex will now look for `:fistbump: x*` or `x* :fistbump:` to apply a multiplier to the recognition so any other x* not prefixing or suffixing a fistbump won't be picked up as a multiplier