### PR TITLE
ci: remove required approval from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,8 +67,6 @@ jobs:
   release:
     name: "Create Release"
     runs-on: ubuntu-latest
-    environment:
-      name: "prod"
     needs: apply
     steps:
       - name: Checkout


### PR DESCRIPTION
Upon reconsideration, we'll go ahead and create the release automatically. If there's a fix needed in nonprod, it would require follow up commits anyway so we'll keep it tracked via releases