### PR TITLE
Remove commit hook execution from CI

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# dont run on CI
+[ -n "$CI" ] && exit 0
+
 npx --no -- commitlint --edit ${1}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+# dont run on CI
+[ -n "$CI" ] && exit 0
+
 npm run lint-fix


### PR DESCRIPTION
Semantic release adds commits to document new releases, the previous git hooks from husky were breaking this process. Since GH Actions is executing linting and we can trust semantic-release to create valid conventional commits, I decided to disable execution in the workflows