### PR TITLE
chore: disable changelog commit and rely on GitHub Releases

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -46,11 +46,5 @@ module.exports = {
         failComment: false,
       },
     ],
-    [
-      "@semantic-release/git",
-      {
-        assets: ["CHANGELOG.md", "package.json", "package-lock.json"],
-      },
-    ],
   ],
 };


### PR DESCRIPTION
This'll disable the commit back to main. Tag & Release creation should still happen via `semantic-release/github` so it'll be better than what we had before.

Long term I'd like to find a better approach for maintaining an active Changelog file

[Relevant](https://github.com/orgs/community/discussions/13836)