### PR TITLE
fix: added check for whitespace before x[num]

### DIFF
--- a/service/recognition.js
+++ b/service/recognition.js
@@ -20,7 +20,7 @@ const tagRegex = /#(\S+)/g;
 const generalEmojiRegex = /:([a-z-_']+):/g;
 const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
 const multiplierRegex = new RegExp(
-  `${config.recognizeEmoji}\\sx([0-9]+)|x([0-9]+)\\s${config.recognizeEmoji}`
+  `${config.recognizeEmoji}\\s*x([0-9]+)|x([0-9]+)\\s${config.recognizeEmoji}`
 );
 
 // TODO Can we add a 'count' field to the recognition?


### PR DESCRIPTION
* Fixed issue where the multiple fistbumps would not work for leading whitespace
* Tested for trailing whitespace and it worked perfectly