### PR TITLE
feat: update nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.12-alpine3.15
+FROM node:22.2-alpine3.19
 WORKDIR /app
 
 COPY package*.json ./


### PR DESCRIPTION
This PR updates the Gratibot NodeJS Version to 22, from 18 which is now out of support. No breaking changes in the Node versions should affect Gratibot. However, this change should be tested as much as possible in non-prod to ensure that no issues make it into production, given the scale of the change.