### PR TITLE
Add Log Analytics

### DIFF
--- a/infra/terraform/cosmosdb.tf
+++ b/infra/terraform/cosmosdb.tf
@@ -5,7 +5,7 @@ resource "azurerm_cosmosdb_account" "db_account" {
   offer_type          = "Standard"
   kind                = "MongoDB"
 
-  enable_automatic_failover = true
+  automatic_failover_enabled = true
 
   capabilities { # forces replacement
     name = "EnableMongo"

--- a/infra/terraform/log-analytics.tf
+++ b/infra/terraform/log-analytics.tf
@@ -1,0 +1,22 @@
+resource "azurerm_log_analytics_workspace" "gratibot" {
+  name                = "gratibot-${var.environment}"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  daily_quota_gb      = 0.5
+}
+
+resource "azurerm_monitor_diagnostic_setting" "gratibot-logs" {
+  name                       = "gratibot-logs"
+  target_resource_id         = azurerm_linux_web_app.gratibot_app_service.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.gratibot.id
+
+  enabled_log {
+    category = "AppServiceConsoleLogs"
+  }
+  metric {
+    category = "AllMetrics"
+    enabled  = false
+  }
+}

--- a/infra/terraform/vault.tf
+++ b/infra/terraform/vault.tf
@@ -11,7 +11,7 @@ resource "azurerm_role_assignment" "gratibot" {
 
 resource "azurerm_key_vault_secret" "mongo_connection_string" {
   name         = "mongo-connection-string"
-  value        = azurerm_cosmosdb_account.db_account.connection_strings[0]
+  value        = azurerm_cosmosdb_account.db_account.primary_mongodb_connection_string
   key_vault_id = data.azurerm_key_vault.gratibot.id
 }
 


### PR DESCRIPTION
Updates names of two deprecated terraform fields for Azure resources. Adds log analytics workspace for exporting gratibot logs

I've manually applied this change in non-prod for testing, so Terraform plan results may not show changes, but expect changes to show up in production when planned there.