### PR TITLE
feat: add Andrew Barefield to unlimited fistbump users

### DIFF
--- a/config.js
+++ b/config.js
@@ -24,6 +24,7 @@ config.usersExemptFromMaximum = process.env.EXEMPT_USERS?.split(",") || [
   "U0K32MUSF", // Robert Kelly
   "U05HA77CE5S", // Ryan McClish
   "U08PEV0SCLW", // Avery Green
+  "U04ALSRL5S7", // Andrew Barefield
 ];
 
 config.initialGoldenRecognitionHolder =


### PR DESCRIPTION
## Summary
- Adds Andrew Barefield (U04ALSRL5S7) to the `usersExemptFromMaximum` list in `config.js`, granting unlimited daily fist bumps.

## Test plan
- [ ] Verify config loads correctly
- [ ] Confirm Andrew Barefield can give unlimited fist bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated user exemption configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->