### PR TITLE
feat: use regular messages instead of ephemeral in DMs

### DIFF
--- a/features/balance.js
+++ b/features/balance.js
@@ -2,6 +2,7 @@ const balance = require("../service/balance");
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { directMessage, anyOf } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
@@ -26,9 +27,7 @@ async function respondToBalance({ message, client }) {
       slackMessage: message.text,
       error: userInfo.error,
     });
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `Something went wrong while obtaining your balance. When retreiving user information from Slack, the API responded with the following error: ${userInfo.error}`,
     });
     return;
@@ -48,9 +47,7 @@ async function respondToBalance({ message, client }) {
     `You have \`${remainingToday}\` left to give away today.`,
   ].join("\n");
 
-  await client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
+  await respondToUser(client, message, {
     text: response,
   });
 

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -4,6 +4,7 @@ const { redemptionAdmins } = require("../config");
 const { userRegex } = require("../regex");
 const { directMention } = require("@slack/bolt");
 const { directMessage, anyOf } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
@@ -28,18 +29,14 @@ async function respondToDeduction({ message, client }) {
       slackMessage: message.text,
       error: userInfo.error,
     });
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `Something went wrong while creating your deduction. When retreiving user information from Slack, the API responded with the following error: ${userInfo.error}`,
     });
     return;
   }
 
   if (!redemptionAdmins.includes(message.user)) {
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `You are not allowed to create deductions.`,
     });
     return;
@@ -52,9 +49,7 @@ async function respondToDeduction({ message, client }) {
     !userRegex.test(messageText[2]) ||
     isNaN(+messageText[3])
   ) {
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `You must specify a user and value to deduct. Example: \`@gratibot deduct @user 5\``,
     });
     return;
@@ -64,9 +59,7 @@ async function respondToDeduction({ message, client }) {
   const value = +messageText[3];
 
   if (!(await deduction.isBalanceSufficent(user, value))) {
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `<@${user}> does not have a large enough balance to deduct ${value} fistbumps.`,
     });
     return;

--- a/features/golden-recognize.js
+++ b/features/golden-recognize.js
@@ -4,6 +4,7 @@ const winston = require("../winston");
 const { SlackError, GratitudeError } = require("../service/errors");
 const { userInfo } = require("../service/apiwrappers");
 const {
+  respondToUser,
   handleSlackError,
   handleGratitudeError,
   handleGenericError,
@@ -53,10 +54,7 @@ async function respondToRecognitionMessage({ message, client }) {
   return Promise.all([
     //send notification to receivers sends a DM from gratibot to the receiver of the fistbump
     sendNotificationToReceivers(client, gratitude),
-    //this call to postEphemeral sends a message only the giver can see in the channel where the fistbump was given
-    client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    respondToUser(client, message, {
       text: `${goldenRecognizeEmoji} has been sent.`,
       ...(await recognition.giverGoldenSlackNotification(gratitude)),
     }),

--- a/features/help.js
+++ b/features/help.js
@@ -7,6 +7,7 @@ const {
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { anyOf, directMessage } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message("help", anyOf(directMention, directMessage()), respondToHelp);
@@ -112,11 +113,7 @@ async function respondToHelp({ message, client }) {
     callingUser: message.user,
     slackMessage: message.text,
   });
-  await client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
-    text: helpMarkdown,
-  });
+  await respondToUser(client, message, { text: helpMarkdown });
 
   winston.debug("successfully posted ephemeral help message to Slack", {
     func: "feature.help.respondToHelp",

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -2,6 +2,7 @@ const leaderboard = require("../service/leaderboard");
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { directMessage, anyOf } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
@@ -24,9 +25,7 @@ async function respondToLeaderboard({ message, client }) {
     callingUser: message.user,
     slackMessage: message.text,
   });
-  await client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
+  await respondToUser(client, message, {
     text: "Gratibot Leaderboard",
     blocks: await leaderboard.createLeaderboardBlocks(30),
   });

--- a/features/metrics.js
+++ b/features/metrics.js
@@ -2,6 +2,7 @@ const metrics = require("../service/metrics");
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { directMessage, anyOf } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
@@ -18,9 +19,7 @@ async function respondToMetrics({ message, client }) {
     callingUser: message.user,
     slackMessage: message.text,
   });
-  await client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
+  await respondToUser(client, message, {
     text: "Gratibot Metrics",
     blocks: await metrics.createMetricsBlocks(30),
   });

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -5,6 +5,7 @@ const { SlackError, GratitudeError } = require("../service/errors");
 const { reactionMatches } = require("../middleware");
 const { userInfo } = require("../service/apiwrappers");
 const {
+  respondToUser,
   handleSlackError,
   handleGratitudeError,
   handleGenericError,
@@ -74,9 +75,7 @@ async function respondToRecognitionMessage({ message, client }) {
 
   return Promise.all([
     sendNotificationToReceivers(client, gratitude),
-    client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    respondToUser(client, message, {
       text: `${recognizeEmoji} has been sent.`,
       ...(await recognition.giverSlackNotification(gratitude)),
     }),
@@ -152,9 +151,7 @@ async function respondToRecognitionReaction({ event, client }) {
 
   return Promise.all([
     sendNotificationToReceivers(client, gratitude),
-    client.chat.postEphemeral({
-      channel: event.channel,
-      user: event.user,
+    respondToUser(client, event, {
       text: `${recognizeEmoji} has been sent.`,
       ...(await recognition.giverSlackNotification(gratitude)),
     }),

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -1,6 +1,7 @@
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { anyOf, directMessage } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 const redeem = require("../service/redeem");
 const balance = require("../service/balance");
 const deduction = require("../service/deduction");
@@ -16,9 +17,7 @@ async function respondToRedeem({ message, client }) {
     slackMessage: message.text,
   });
   const currentBalance = await balance.currentBalance(message.user);
-  await client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
+  await respondToUser(client, message, {
     text: "Gratibot Rewards",
     blocks: await redeem.createRedeemBlocks(currentBalance),
   });

--- a/features/report.js
+++ b/features/report.js
@@ -3,6 +3,7 @@ const report = require("../service/report");
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
 const { directMessage, anyOf } = require("../middleware");
+const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   // Handle direct "report" command
@@ -59,10 +60,7 @@ async function respondToReport({ message, client }) {
       timeRange,
     );
 
-    // Send the report as an ephemeral message
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: `Top recognized messages for <@${targetUserId}>`,
       blocks: blocks,
     });
@@ -81,9 +79,7 @@ async function respondToReport({ message, client }) {
       error: error.message,
     });
 
-    await client.chat.postEphemeral({
-      channel: message.channel,
-      user: message.user,
+    await respondToUser(client, message, {
       text: "An unexpected error occurred while generating the report. Please try again later.",
     });
   }

--- a/service/messageutils.js
+++ b/service/messageutils.js
@@ -3,6 +3,20 @@ const config = require("../config");
 const recognition = require("./recognition");
 const { recognizeEmoji, goldenRecognizeEmoji } = config;
 
+async function respondToUser(client, messageContext, options) {
+  if (messageContext.channel_type === "im") {
+    return client.chat.postMessage({
+      channel: messageContext.channel,
+      ...options,
+    });
+  }
+  return client.chat.postEphemeral({
+    channel: messageContext.channel,
+    user: messageContext.user,
+    ...options,
+  });
+}
+
 async function handleSlackError(client, message, error) {
   winston.error("Slack API returned an error response", {
     apiMethod: error.apiMethod,
@@ -60,6 +74,7 @@ function getRecieverMessage(gratitude) {
 }
 
 module.exports = {
+  respondToUser,
   handleSlackError,
   handleGratitudeError,
   handleGenericError,

--- a/service/messageutils.js
+++ b/service/messageutils.js
@@ -22,11 +22,7 @@ async function handleSlackError(client, message, error) {
     apiMethod: error.apiMethod,
     apiError: error.apiError,
   });
-  return client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
-    text: error.userMessage,
-  });
+  return respondToUser(client, message, { text: error.userMessage });
 }
 
 async function handleGratitudeError(client, message, error) {
@@ -34,9 +30,7 @@ async function handleGratitudeError(client, message, error) {
     gratitudeErrors: error.gratitudeErrors,
   });
   const errorString = error.gratitudeErrors.join("\n");
-  return client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
+  return respondToUser(client, message, {
     text: `Sending gratitude failed with the following error(s):\n${errorString}`,
   });
 }
@@ -46,11 +40,7 @@ async function handleGenericError(client, message, error) {
     error,
   });
   const userMessage = `An unknown error occured in Gratibot: ${error.message}`;
-  return client.chat.postEphemeral({
-    channel: message.channel,
-    user: message.user,
-    text: userMessage,
-  });
+  return respondToUser(client, message, { text: userMessage });
 }
 
 async function sendNotificationToReceivers(client, gratitude) {

--- a/test/service/messageutils.js
+++ b/test/service/messageutils.js
@@ -68,6 +68,7 @@ describe("service/messageutils", () => {
     it("should return the proper message", async () => {
       const testClient = {
         chat: {
+          postMessage: sinon.stub(),
           postEphemeral: sinon.stub(),
         },
       };
@@ -92,6 +93,7 @@ describe("service/messageutils", () => {
     it("should return the proper message", async () => {
       const testClient = {
         chat: {
+          postMessage: sinon.stub(),
           postEphemeral: sinon.stub(),
         },
       };
@@ -120,6 +122,7 @@ describe("service/messageutils", () => {
     it("should return the proper message", async () => {
       const testClient = {
         chat: {
+          postMessage: sinon.stub(),
           postEphemeral: sinon.stub(),
         },
       };

--- a/test/service/messageutils.js
+++ b/test/service/messageutils.js
@@ -23,8 +23,14 @@ describe("service/messageutils", () => {
     });
 
     it("should use postMessage when channel_type is im", async () => {
-      const messageContext = { channel: "D123", user: "U123", channel_type: "im" };
-      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      const messageContext = {
+        channel: "D123",
+        user: "U123",
+        channel_type: "im",
+      };
+      await messageutils.respondToUser(testClient, messageContext, {
+        text: "hello",
+      });
       sinon.assert.calledOnce(testClient.chat.postMessage);
       sinon.assert.notCalled(testClient.chat.postEphemeral);
       sinon.assert.calledWith(testClient.chat.postMessage, {
@@ -34,8 +40,14 @@ describe("service/messageutils", () => {
     });
 
     it("should use postEphemeral when channel_type is not im", async () => {
-      const messageContext = { channel: "C123", user: "U123", channel_type: "channel" };
-      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      const messageContext = {
+        channel: "C123",
+        user: "U123",
+        channel_type: "channel",
+      };
+      await messageutils.respondToUser(testClient, messageContext, {
+        text: "hello",
+      });
       sinon.assert.calledOnce(testClient.chat.postEphemeral);
       sinon.assert.notCalled(testClient.chat.postMessage);
       sinon.assert.calledWith(testClient.chat.postEphemeral, {
@@ -47,15 +59,26 @@ describe("service/messageutils", () => {
 
     it("should use postEphemeral when channel_type is missing", async () => {
       const messageContext = { channel: "C123", user: "U123" };
-      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      await messageutils.respondToUser(testClient, messageContext, {
+        text: "hello",
+      });
       sinon.assert.calledOnce(testClient.chat.postEphemeral);
       sinon.assert.notCalled(testClient.chat.postMessage);
     });
 
     it("should pass through blocks and extra options", async () => {
-      const messageContext = { channel: "D123", user: "U123", channel_type: "im" };
-      const blocks = [{ type: "section", text: { type: "mrkdwn", text: "hi" } }];
-      await messageutils.respondToUser(testClient, messageContext, { text: "hello", blocks });
+      const messageContext = {
+        channel: "D123",
+        user: "U123",
+        channel_type: "im",
+      };
+      const blocks = [
+        { type: "section", text: { type: "mrkdwn", text: "hi" } },
+      ];
+      await messageutils.respondToUser(testClient, messageContext, {
+        text: "hello",
+        blocks,
+      });
       sinon.assert.calledWith(testClient.chat.postMessage, {
         channel: "D123",
         text: "hello",

--- a/test/service/messageutils.js
+++ b/test/service/messageutils.js
@@ -10,6 +10,60 @@ describe("service/messageutils", () => {
     sinon.restore();
   });
 
+  describe("respondToUser", () => {
+    let testClient;
+
+    beforeEach(() => {
+      testClient = {
+        chat: {
+          postMessage: sinon.stub(),
+          postEphemeral: sinon.stub(),
+        },
+      };
+    });
+
+    it("should use postMessage when channel_type is im", async () => {
+      const messageContext = { channel: "D123", user: "U123", channel_type: "im" };
+      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      sinon.assert.calledOnce(testClient.chat.postMessage);
+      sinon.assert.notCalled(testClient.chat.postEphemeral);
+      sinon.assert.calledWith(testClient.chat.postMessage, {
+        channel: "D123",
+        text: "hello",
+      });
+    });
+
+    it("should use postEphemeral when channel_type is not im", async () => {
+      const messageContext = { channel: "C123", user: "U123", channel_type: "channel" };
+      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      sinon.assert.calledOnce(testClient.chat.postEphemeral);
+      sinon.assert.notCalled(testClient.chat.postMessage);
+      sinon.assert.calledWith(testClient.chat.postEphemeral, {
+        channel: "C123",
+        user: "U123",
+        text: "hello",
+      });
+    });
+
+    it("should use postEphemeral when channel_type is missing", async () => {
+      const messageContext = { channel: "C123", user: "U123" };
+      await messageutils.respondToUser(testClient, messageContext, { text: "hello" });
+      sinon.assert.calledOnce(testClient.chat.postEphemeral);
+      sinon.assert.notCalled(testClient.chat.postMessage);
+    });
+
+    it("should pass through blocks and extra options", async () => {
+      const messageContext = { channel: "D123", user: "U123", channel_type: "im" };
+      const blocks = [{ type: "section", text: { type: "mrkdwn", text: "hi" } }];
+      await messageutils.respondToUser(testClient, messageContext, { text: "hello", blocks });
+      sinon.assert.calledWith(testClient.chat.postMessage, {
+        channel: "D123",
+        text: "hello",
+        blocks,
+      });
+    });
+  });
+
   describe("handleSlackError", () => {
     it("should return the proper message", async () => {
       const testClient = {


### PR DESCRIPTION
## Why

Gratibot currently sends all responses (balance, leaderboard, metrics, etc.) as ephemeral messages, even in direct message conversations. Ephemeral messages are invisible to other Slack bots and disappear from message history, which prevents any integration that needs to read Gratibot's responses programmatically.

In a DM conversation, ephemeral messages are unnecessary since the conversation is already private between the user and the bot.

## What

This PR introduces a `respondToUser` helper that checks `message.channel_type`:

- **In DMs** (`channel_type === "im"`): responds with `chat.postMessage` (regular message, persistent, visible to other bots)
- **In channels**: responds with `chat.postEphemeral` (unchanged behavior)

All feature files and error handlers now route through this helper instead of calling `postEphemeral` directly.

## How to review

1. Start with `service/messageutils.js` to see the new `respondToUser` function and how the three error handlers were updated to use it
2. Each feature file change is mechanical: import `respondToUser`, replace `client.chat.postEphemeral({channel, user, text, ...})` with `respondToUser(client, message, {text, ...})`
3. The `redeem.js` action handler (line 43) is intentionally unchanged because it uses `body.channel.id` rather than a message context
4. Reaction events (`event` objects) lack `channel_type`, so they correctly fall through to ephemeral

## Test plan

- [ ] All existing tests pass (117 passing)
- [ ] New unit tests cover `respondToUser` for DM, channel, and missing `channel_type` cases
- [ ] DM Gratibot with "balance" and verify response is a regular (non-ephemeral) message
- [ ] In a channel, @gratibot balance and verify response is still ephemeral
- [ ] Send a fistbump in a channel and verify confirmation is still ephemeral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized message delivery across all bot features through a shared utility helper, improving code consistency and maintainability across balance, deduction, recognition, help, leaderboard, metrics, redeem, and report functions.

* **Tests**
  * Added comprehensive test coverage for the new message utility, including direct message and ephemeral message handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->