### PR TITLE
Update triggers

### DIFF
--- a/features/balance.js
+++ b/features/balance.js
@@ -6,7 +6,7 @@ const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
-    "balance",
+    /balance/i,
     anyOf(directMention, directMessage()),
     respondToBalance,
   );

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -8,7 +8,7 @@ const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
-    "deduct",
+    /deduct/i,
     anyOf(directMention, directMessage()),
     respondToDeduction,
   );

--- a/features/help.js
+++ b/features/help.js
@@ -10,7 +10,7 @@ const { anyOf, directMessage } = require("../middleware");
 const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
-  app.message("help", anyOf(directMention, directMessage()), respondToHelp);
+  app.message(/help/i, anyOf(directMention, directMessage()), respondToHelp);
   app.message(/(thunderfury|Thunderfury)/, respondToEasterEgg);
 };
 

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -6,7 +6,7 @@ const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
-    "leaderboard",
+    /leaderboard/i,
     anyOf(directMessage(), directMention),
     respondToLeaderboard,
   );

--- a/features/metrics.js
+++ b/features/metrics.js
@@ -6,7 +6,7 @@ const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
   app.message(
-    "metrics",
+    /metrics/i,
     anyOf(directMessage(), directMention),
     respondToMetrics,
   );

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -7,7 +7,7 @@ const balance = require("../service/balance");
 const deduction = require("../service/deduction");
 
 module.exports = function (app) {
-  app.message("redeem", anyOf(directMention, directMessage()), respondToRedeem);
+  app.message(/redeem/i, anyOf(directMention, directMessage()), respondToRedeem);
   app.action({ action_id: "redeem" }, redeemItem);
 };
 

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -7,7 +7,11 @@ const balance = require("../service/balance");
 const deduction = require("../service/deduction");
 
 module.exports = function (app) {
-  app.message(/redeem/i, anyOf(directMention, directMessage()), respondToRedeem);
+  app.message(
+    /redeem/i,
+    anyOf(directMention, directMessage()),
+    respondToRedeem,
+  );
   app.action({ action_id: "redeem" }, redeemItem);
 };
 

--- a/features/refund.js
+++ b/features/refund.js
@@ -7,7 +7,7 @@ const refund = require("../service/refund");
 
 module.exports = function (app) {
   app.message(
-    "refund",
+    /refund/i,
     anyOf(directMention, directMessage()),
     refund.respondToRefund,
   );


### PR DESCRIPTION
Updating trigger words to not be case-sensitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Slack bot commands now accept any capitalization for: balance, help, metrics, leaderboard, redeem, deduction, and refund — making triggers case-insensitive so messages like "Balance", "HELP", or "ReDeEm" will invoke the same responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->