### PR TITLE
fix(ci): pin setup-node and yq to explicit version SHAs

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-        uses: actions/setup-node@master
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Checkout Code

--- a/.github/workflows/publish-techdocs-to-s3.yaml
+++ b/.github/workflows/publish-techdocs-to-s3.yaml
@@ -95,42 +95,42 @@ jobs:
       - name: Get namespace from catalog-info.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.catalog-present == 'true' }}
         id: get_namespace_catalog
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.metadata.namespace // "default"' catalog-info.yaml
 
       - name: Get name from catalog-info.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.catalog-present == 'true' }}
         id: get_name_catalog
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.metadata.name' catalog-info.yaml
 
       - name: Get kind from catalog-info.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.catalog-present == 'true' }}
         id: get_kind_catalog
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.kind' catalog-info.yaml
 
       - name: Get namespace from template.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.template-present == 'true' }}
         id: get_namespace_template
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.metadata.namespace // "default"' template.yaml
 
       - name: Get name from template.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.template-present == 'true' }}
         id: get_name_template
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.metadata.name' template.yaml
 
       - name: Get kind from template.yaml
         if: ${{ needs.check-for-catalog-info-at-root.outputs.template-present == 'true' }}
         id: get_kind_template
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq '.kind' template.yaml
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Node
-        uses: actions/setup-node@master
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 24
       - name: Checkout Code


### PR DESCRIPTION
## Summary

- Several workflows reference `actions/setup-node@master` and `mikefarah/yq@master`. Both of those `master` branches have been abandoned — they point at commits from 2021 and earlier.
- `actions/setup-node@master` specifically resolves to a January 2021 commit that uses the long-deprecated `::add-path::` workflow command. GitHub has now fully disabled that command, which is what broke #865 (renovate pinned SHAs by resolving `master` via the branch API, locking in the dead commit).
- This PR replaces all `@master` references with pinned SHAs matching a recent release tag (pattern already used elsewhere in the repo).

## Changes
- `actions/setup-node@master` → `@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0` (same SHA already used in `release.yml` / `publish-techdocs-to-s3.yaml`)
- `mikefarah/yq@master` (6 occurrences) → `@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5`

After this lands, #865 can be regenerated by renovate against the stable version tags.

## Test plan
- [ ] `lint` workflow runs successfully on this PR
- [ ] `test` workflow runs successfully on this PR
- [ ] Confirm no new failures on `publish-techdocs-to-s3.yaml` (only triggered on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions workflow dependencies to specific commit versions for improved build reproducibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->