### PR TITLE
chore(renovate): ignore docs directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   "labels": ["renovate"],
   "timezone": "America/Los_Angeles",
   "schedule": ["* * * * 0,6"],
+  "ignorePaths": ["docs/**"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary
- Adds `ignorePaths: ["docs/**"]` to `renovate.json` so Renovate no longer updates snapshot files under `docs/specs/**/proofs/` when bumping dependencies.
- Spec proof artifacts should be point-in-time records, not track live config.

## Context
Noticed in PR #887 and #885: Renovate was updating both `mise.toml` and `docs/specs/03-spec-ci-cd-hardening/03-proofs/mise.toml`, where the latter is a proof/snapshot file.

## Test plan
- [ ] Merge and confirm next Renovate cycle (Sat/Sun) only touches non-`docs/**` paths.
- [ ] After merging, close/rebase #887 so it drops the docs file change on next rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)