### PR TITLE
chore: docker compose v2 watch + help command cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,8 +42,8 @@ npm run lint
 # Start the bot (requires .env with Slack tokens)
 npm start
 
-# Start the full stack locally (bot + MongoDB) via Docker
-docker-compose up --build
+# Start the full stack locally (bot + MongoDB) via Docker with hot reload
+docker compose up --build --watch
 ```
 
 Minimum environment to run the bot — create a `.env` file at the project root:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ something like:
     not publish them online such as by pushing them to GitHub.***
 
 5. Now that your secrets are configured, run your local copy
-of Gratibot with `docker-compose up --build`
+of Gratibot with `docker compose up --build --watch`. The `--watch` flag
+syncs local edits into the running container and restarts the bot
+automatically.
 
 With all of these steps complete, your bot should be running in the Slack
 workspace you chose to develop for. You should now be ready to test your bot,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,6 +21,26 @@ services:
       - REDEMPTION_ADMINS
       - BOT_NAME
       - SLASH_COMMAND
+    develop:
+      watch:
+        - action: sync+restart
+          path: .
+          target: /app
+          ignore:
+            - node_modules/
+            - test/
+            - docs/
+            - infra/
+            - .git/
+            - .github/
+            - .husky/
+            - coverage/
+        - action: rebuild
+          path: package.json
+        - action: rebuild
+          path: package-lock.json
+        - action: rebuild
+          path: Dockerfile
   mongodb:
     ports:
       - 27017:27017

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -70,10 +70,13 @@ See the [Environment Variables Reference](#environment-variables-reference) belo
 
 ### 5. Start the Bot
 
-**Full stack (recommended):** runs the bot and MongoDB together via Docker Compose:
+**Full stack (recommended):** runs the bot and MongoDB together via Docker Compose
+with hot reload. The `--watch` flag syncs local edits into the running container and
+restarts the bot automatically; changes to `package.json`, `package-lock.json`, or the
+`Dockerfile` trigger a rebuild.
 
 ```bash
-docker-compose up --build
+docker compose up --build --watch
 ```
 
 **Bot only** (requires a running MongoDB at `MONGO_URL`):

--- a/docs/local_dev/running_bot.md
+++ b/docs/local_dev/running_bot.md
@@ -19,7 +19,9 @@
    not publish them online such as by pushing them to GitHub._**
 
 4. Now that your secrets are configured, run your local copy
-   of Gratibot with `docker-compose up --build`
+   of Gratibot with `docker compose up --build --watch`. The `--watch`
+   flag syncs local edits into the running container and restarts the
+   bot automatically.
 
 With all of these steps complete, your bot should be running in the Slack
 workspace you chose to develop for. You should now be ready to test your bot,

--- a/features/help.js
+++ b/features/help.js
@@ -14,97 +14,52 @@ module.exports = function (app) {
   app.message(/(thunderfury|Thunderfury)/, respondToEasterEgg);
 };
 
+const divider = "━━━━━━━━━━━━━━━━━━━━";
+
 const helpMarkdown = `
-:wave: Hi there! Let's take a look at what I can do!
+:wave: Hi there! Here's what I can do.
 
+${divider}
 
+*Give Recognition* (up to ${maximum} per day)
 
-
-*Give Recognition*
-
-You can give up to ${maximum} recognitions per day.
-
-First, make sure I have been invited to the channel you want to recognize \
-someone in. Then, write a brief message describing what someone did, \
-\`@mention\` them and include the ${recognizeEmoji} emoji...I'll take it from there!
+Invite me to the channel, then mention someone, describe what they did, and add ${recognizeEmoji}.
 
 > Thanks @alice for helping me fix my pom.xml ${recognizeEmoji}
 
-Recognize multiple people at once!
+• Recognize multiple people at once — \`@bob and @alice crushed the showcase! ${recognizeEmoji}\`
+• Tag Liatrio values with \`#tags\` — \`I love the #energy in your demo @alice! ${recognizeEmoji}\`
+• Boost with extra emoji or a multiplier — \`${recognizeEmoji} ${recognizeEmoji} ${recognizeEmoji}\` or \`${recognizeEmoji} x2\`
+• Second someone else's shout-out by reacting with ${reactionEmoji}
 
-> @bob and @alice crushed that showcase! ${recognizeEmoji}
+${divider}
 
-Use \`#tags\` to call out specific Liatrio values!
+*Golden Fistbump* ${goldenRecognizeEmoji}
 
-> I love the #energy in your Terraform demo @alice! ${recognizeEmoji}
+Only the current holder can pass it on. Use it like any other fistbump:
 
-The more emojis you add, the more recognition they get!
+> Thanks @alice for fixing prod! ${goldenRecognizeEmoji}
 
-> @alice just pushed the cleanest code I've ever seen! ${recognizeEmoji} ${recognizeEmoji} ${recognizeEmoji}
+The new holder receives 20 ${recognizeEmoji} immediately, plus a 2x multiplier on all recognition they receive while holding it.
 
-Use multipliers to give more recognition!
+${divider}
 
-> @alice presented an amazing demo at a conference! ${recognizeEmoji} x2
+*Check Your Status* (DM me one of these)
 
-or
+• \`balance\` — how many ${recognizeEmoji} you've received and have left to give today
+• \`leaderboard\` — top givers, top receivers, and the current ${goldenRecognizeEmoji} holder
+• \`metrics\` — recognition activity over the last month
+• \`report\` — your top reasons for recognition over the past month, six months, or year. Use \`report @user\` to view someone else's — handy for biannual reviews.
 
-> @alice presented an amazing demo at a conference! x2 ${recognizeEmoji}
+${divider}
 
-If someone else has given a ${recognizeEmoji} to someone, and you'd like to \
-give one of your own for the same reason, you can react to the message with \
-a ${reactionEmoji}. Gratibot will record your shout-out as though you sent \
-the same message that you reacted to.
+*Redeem Rewards*
 
-*Redeeming*
+DM me \`redeem\` to browse prizes. Once you pick one, I'll loop in a redemption admin to finalize it.
 
-
-Send me a direct message with 'redeem' and I'll give you the options for prizes to redeem! Once you've selcted an item then I'll start a MPIM with the redemption admins to promote the dialog to acknowledge and receive your item.
-
-Refunds can be given via the 'refund' command if the item redeem can't be fulfilled for whatever reason. Only redemption admins can give refunds. Deduction ID is sent as part of the MPIM when an item is redeemed
+If a redemption can't be fulfilled, admins can refund it using the deduction ID from the redemption message:
 
 > @gratibot refund DEDUCTIONID
-
-
-*View Balance*
-
-Send me a direct message with 'balance' and I'll let you know how many \
-recognitions you have left to give and how many you have received.
-
-> You have received 0 ${recognizeEmoji} and you have ${maximum} ${recognizeEmoji} remaining to \
-give away today
-
-
-*View Leaderboard*
-
-Send me a direct message with 'leaderboard' and I'll show you who is giving \
-and receiving the most recognition. I'll also show who currently holds the :goldenfistbump:!
-
-
-*View Metrics*
-
-Send me a direct message with 'metrics' and I'll show you how many times \
-people have given recognitions over the last month.
-
-
-*View Report: Top Reasons for Recognition*
-
-Send me a direct message with 'report' to see the top reasons you've \
-received fistbumps over the past month, six months, or year.
-
-To see a report for someone else, use 'report @example-user'.
-
-Great for remembering accomplishments when writing biannual reviews.
-
-
-*Give Golden Recognition*
-
-The golden fistbump ${goldenRecognizeEmoji} is a special recognition that can only be held by one user at a time. Only the current holder of the golden recognition can give the golden recognition.
-
-Giving a golden fistbump is the same as giving a normal fistbump
-
-> Thanks @alice for helping fix the prod issues! ${goldenRecognizeEmoji}
-
-Upon receiving the golden fistbump, the user will receive 20 fistbumps and will have a 2X multiplier applied to all incoming fistbumps while the golden fistbump is held. 
 `;
 
 async function respondToHelp({ message, client }) {

--- a/test/features/help.js
+++ b/test/features/help.js
@@ -30,7 +30,8 @@ describe("features/help", () => {
       const args = postMessage.firstCall.args[0];
       expect(args.channel).to.equal("Ddm");
       expect(args.text).to.include("Give Recognition");
-      expect(args.text).to.include("View Balance");
+      expect(args.text).to.include("Check Your Status");
+      expect(args.text).to.include("Redeem Rewards");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add `develop.watch` to `docker-compose.yaml` so `docker compose up --build --watch` syncs local source edits into the running container and rebuilds automatically on `package.json`, `package-lock.json`, or `Dockerfile` changes.
- Promote `docker compose up --build --watch` as the recommended local workflow across `README.md`, `AGENTS.md`, `docs/DEVELOPMENT.md`, and `docs/local_dev/running_bot.md` — dropping the legacy v1 `docker-compose` invocation along the way.
- Restructure the `/gratibot help` output into four clearly delimited sections (Give Recognition, Golden Fistbump, Check Your Status, Redeem Rewards) with bulleted examples, visual dividers, and the long-standing `selcted` typo fixed.

## Test plan

- [x] \`npm test\` (240 passing)
- [x] \`npm run lint\`
- [x] Manual: run \`docker compose up --build --watch\` locally, edit a file under \`features/\` and confirm the bot restarts without a rebuild
- [x] Manual: DM \`help\` to the dev bot and verify dividers and sections render correctly in Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned help documentation with clearer "Check Your Status" and "Redeem Rewards" sections.
  * Added support for multi-recognition, value tagging with hashtags, and emoji reactions for enhanced shout-outs.

* **Documentation**
  * Updated local development setup instructions with automatic code sync and container restart for faster iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->