### PR TITLE
fix: address audit issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,13 +3,6 @@ const express = require("express");
 const webserver = express();
 const winston = require("./winston");
 const client = require("./database/db");
-const {
-  recognizeEmoji,
-  maximum,
-  reactionEmoji,
-  goldenRecognizeEmoji,
-  slashCommand,
-} = require("./config");
 
 const app = new App({
   token: process.env.BOT_USER_OAUTH_ACCESS_TOKEN,
@@ -70,45 +63,6 @@ webserver.get("/health", async (req, res) => {
   winston.debug("Health check passed");
 });
 
-/// ////////////////////////////////////////////////////////////
-// Slash Command Logic //
-/// ////////////////////////////////////////////////////////////
-
-function parseCommand(command) {
-  const parsed = {
-    // Default values for each parameter
-    valid: false, // indicates if a command is valid
-    command: "", // holds the type of command
-    user: "", // holds the value for the user that will be targeted
-  };
-
-  const raw = command.text.split(" "); // raw command as an array
-  parsed.command = raw[0];
-
-  switch (raw[0]) {
-    case "help":
-      parsed.valid = true; // command is valid, but doesn't require any additional info
-      break;
-  }
-
-  // if none of the above cases are true, parsed.valid will stay false
-
-  return parsed;
-}
-
-app.command(slashCommand, async ({ command, ack, respond }) => {
-  await ack();
-  const userCommand = parseCommand(command);
-
-  switch (userCommand.command) {
-    case "help":
-      await respond(helpMarkdown);
-      break;
-    default:
-      await respond(errorMarkdown);
-  }
-});
-
 (async () => {
   try {
     await client.connect();
@@ -131,102 +85,3 @@ app.command(slashCommand, async ({ command, ack, respond }) => {
     process.exit(1);
   }
 })();
-
-/// ////////////////////////////////////////////////////////////
-// Variables //
-/// ////////////////////////////////////////////////////////////
-
-const errorMarkdown = `
-:well: Command does not exist.
-Here is a list of commands that actually work:
-
-/gratibot help: talks about what Gratibot can do!
-`;
-
-// Text is rendered into help command
-const helpMarkdown = `
-:wave: Hi there! Let's take a look at what I can do!
-
-
-
-
-*Give Recognition*
-
-You can give up to ${maximum} recognitions per day.
-
-First, make sure I have been invited to the channel you want to recognize \
-someone in. Then, write a brief message describing what someone did, \
-\`@mention\` them and include the ${recognizeEmoji} emoji...I'll take it from there!
-
-> Thanks @alice for helping me fix my pom.xml ${recognizeEmoji}
-
-Recognize multiple people at once!
-
-> @bob and @alice crushed that showcase! ${recognizeEmoji}
-
-Use \`#tags\` to call out specific Liatrio values!
-
-> I love the #energy in your Terraform demo @alice! ${recognizeEmoji}
-
-The more emojis you add, the more recognition they get!
-
-> @alice just pushed the cleanest code I've ever seen! ${recognizeEmoji} ${recognizeEmoji} ${recognizeEmoji}
-
-Use multipliers to give more recognition!
-
-> @alice presented an amazing demo at a conference! ${recognizeEmoji} x2
-
-or
-
-> @alice presented an amazing demo at a conference! x2 ${recognizeEmoji}
-
-If someone else has given a ${recognizeEmoji} to someone, and you'd like to \
-give one of your own for the same reason, you can react to the message with \
-a ${reactionEmoji}. Gratibot will record your shout-out as though you sent \
-the same message that you reacted to.
-
-*Redeeming*
-
-
-Send me a direct message with 'redeem' and I'll give you the options for prizes to redeem! Once you've selcted an item then I'll start a MPIM with the redemption admins to promote the dialog to acknowledge and receive your item.
-
-Refunds can be given via the 'refund' command if the item redeem can't be fulfilled for whatever reason. Only redemption admins can give refunds. Deduction ID is sent as part of the MPIM when an item is redeemed
-
-> @gratibot refund DEDUCTIONID
-
-
-*View Balance*
-
-Send me a direct message with 'balance' and I'll let you know how many \
-recognitions you have left to give and how many you have received.
-
-> You have received 0 ${recognizeEmoji} and you have ${maximum} ${recognizeEmoji} remaining to \
-give away today
-
-
-
-
-*View Leaderboard*
-
-Send me a direct message with 'leaderboard' and I'll show you who is giving \
-and receiving the most recognition. I'll also show who currently holds the :goldenfistbump:!
-
-
-
-
-*View Metrics*
-
-Send me a direct message with 'metrics' and I'll show you how many times \
-people have given recognitions over the last month.
-
-
-*Give Golden Recognition*
-
-The golden fistbump ${goldenRecognizeEmoji} is a special recognition that can only be held by one user at a time. Only the current holder of the golden recognition can give the golden recognition.
-
-Giving a golden fistbump is the same as giving a normal fistbump
-
-> Thanks @alice for helping fix the prod issues! ${goldenRecognizeEmoji}
-
-Upon receiving the golden fistbump, the user will receive 20 fistbumps and will have a 2X multiplier applied to all incoming fistbumps while the golden fistbump is held.
-`;

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -58,7 +58,7 @@ async function respondToDeduction({ message, client }) {
   const user = messageText[2].match(userRegex)[1];
   const value = +messageText[3];
 
-  if (!(await deduction.isBalanceSufficent(user, value))) {
+  if (!(await deduction.isBalanceSufficient(user, value))) {
     await respondToUser(client, message, {
       text: `<@${user}> does not have a large enough balance to deduct ${value} fistbumps.`,
     });

--- a/features/join.js
+++ b/features/join.js
@@ -10,7 +10,7 @@ module.exports = function (app) {
 
 async function joinPublicChannel({ event, client }) {
   try {
-    client.conversations.join({ channel: event.channel.id });
+    await client.conversations.join({ channel: event.channel.id });
   } catch (e) {
     if (e instanceof SlackError) {
       return handleSlackError(client, event, e);

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -38,10 +38,6 @@ async function redeemItem({ ack, body, context, client }) {
       token: context.botToken,
       users: redeem.redeemNotificationUsers(userID),
     });
-    await client.conversations.list({
-      token: context.botToken,
-      types: "mpim, im",
-    });
     const { itemName, itemCost, kind } = redeem.getSelectedItemDetails(
       body.actions[0].selected_option.value,
     );
@@ -77,5 +73,14 @@ async function redeemItem({ ack, body, context, client }) {
       callingUser: userID,
       error: error.message,
     });
+    try {
+      await client.chat.postEphemeral({
+        channel: body.channel.id,
+        user: userID,
+        text: "Something went wrong processing your redemption. Please try again or contact an admin.",
+      });
+    } catch {
+      // best-effort; nothing more we can do
+    }
   }
 }

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -42,7 +42,7 @@ async function redeemItem({ ack, body, context, client }) {
       body.actions[0].selected_option.value,
     );
 
-    if (!(await deduction.isBalanceSufficent(userID, itemCost))) {
+    if (!(await deduction.isBalanceSufficient(userID, itemCost))) {
       return client.chat.postEphemeral({
         channel: body.channel.id,
         user: userID,

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -24,7 +24,7 @@ function anyOf(...funcs) {
 
 function reactionMatches(emoji) {
   return async ({ event, next }) => {
-    if (emoji[0] == ":" && emoji[emoji.length - 1] == ":") {
+    if (emoji[0] === ":" && emoji[emoji.length - 1] === ":") {
       emoji = emoji.slice(1, -1);
     }
     if (event.reaction.includes(emoji)) {

--- a/service/deduction.js
+++ b/service/deduction.js
@@ -43,7 +43,7 @@ async function getDeductions(user, timezone = null, days = null) {
   }
 
   winston.debug(`retrieving ${user}'s deductions`, {
-    func: "service.deduction.createDeduction",
+    func: "service.deduction.getDeductions",
     callingUser: user,
     timezone: timezone,
     days: days,
@@ -52,7 +52,7 @@ async function getDeductions(user, timezone = null, days = null) {
   return await deductionCollection.find(filter).toArray();
 }
 
-async function isBalanceSufficent(user, deductionValue) {
+async function isBalanceSufficient(user, deductionValue) {
   return (await balance.currentBalance(user)) >= deductionValue;
 }
 
@@ -60,5 +60,5 @@ module.exports = {
   createDeduction,
   refundDeduction,
   getDeductions,
-  isBalanceSufficent,
+  isBalanceSufficient,
 };

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -179,9 +179,7 @@ async function gratitudeReceiverIdsIn(client, text) {
 
 function gratitudeCountIn(text) {
   const emojiCount = (text.match(gratitudeEmojiRegex) || []).length;
-  const multiplierFinding = text.match(multiplierRegex)
-    ? text.match(multiplierRegex).filter(Boolean)
-    : null;
+  const multiplierFinding = text.match(multiplierRegex)?.filter(Boolean);
   const multiplier = multiplierFinding ? multiplierFinding[1] : 1;
   return emojiCount * multiplier;
 }
@@ -220,7 +218,7 @@ async function gratitudeErrors(gratitude) {
       ? "- Mention who you want to recognize with @user"
       : "",
 
-    gratitude.receivers.find((x) => x.id == gratitude.giver.id) &&
+    gratitude.receivers.find((x) => x.id === gratitude.giver.id) &&
     gratitude.receivers.length === 1
       ? "- You can't recognize yourself"
       : "",

--- a/test/features/deduction.js
+++ b/test/features/deduction.js
@@ -50,9 +50,9 @@ describe("features/deduction", () => {
       client.users.info = sinon
         .stub()
         .resolves({ ok: false, error: "user_not_found" });
-      const isBalanceSufficentStub = sinon.stub(
+      const isBalanceSufficientStub = sinon.stub(
         deduction,
-        "isBalanceSufficent",
+        "isBalanceSufficient",
       );
 
       const message = {
@@ -64,7 +64,7 @@ describe("features/deduction", () => {
 
       await handler({ message, client });
 
-      expect(isBalanceSufficentStub.called).to.equal(false);
+      expect(isBalanceSufficientStub.called).to.equal(false);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
       const args = client.chat.postMessage.firstCall.args[0];
       expect(args.text).to.include(
@@ -80,9 +80,9 @@ describe("features/deduction", () => {
       const handler = findHandler("message", /deduct/i);
 
       const client = buildClient();
-      const isBalanceSufficentStub = sinon.stub(
+      const isBalanceSufficientStub = sinon.stub(
         deduction,
-        "isBalanceSufficent",
+        "isBalanceSufficient",
       );
       const message = {
         user: "Unotadmin",
@@ -93,7 +93,7 @@ describe("features/deduction", () => {
 
       await handler({ message, client });
 
-      expect(isBalanceSufficentStub.called).to.equal(false);
+      expect(isBalanceSufficientStub.called).to.equal(false);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
       expect(client.chat.postMessage.firstCall.args[0].text).to.include(
         "You are not allowed to create deductions",
@@ -107,9 +107,9 @@ describe("features/deduction", () => {
       const handler = findHandler("message", /deduct/i);
 
       const client = buildClient();
-      const isBalanceSufficentStub = sinon.stub(
+      const isBalanceSufficientStub = sinon.stub(
         deduction,
-        "isBalanceSufficent",
+        "isBalanceSufficient",
       );
 
       const malformedTexts = [
@@ -130,7 +130,7 @@ describe("features/deduction", () => {
         });
       }
 
-      expect(isBalanceSufficentStub.called).to.equal(false);
+      expect(isBalanceSufficientStub.called).to.equal(false);
       expect(client.chat.postMessage.callCount).to.equal(malformedTexts.length);
       client.chat.postMessage.getCalls().forEach((call) => {
         expect(call.args[0].text).to.include(
@@ -139,13 +139,13 @@ describe("features/deduction", () => {
       });
     });
 
-    it("should post an insufficient-balance message when deduction.isBalanceSufficent returns false", async () => {
+    it("should post an insufficient-balance message when deduction.isBalanceSufficient returns false", async () => {
       setAdmins(["Uadmin"]);
       const { app, findHandler } = createMockApp();
       deductionFeature(app);
       const handler = findHandler("message", /deduct/i);
 
-      sinon.stub(deduction, "isBalanceSufficent").resolves(false);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(false);
       const createDeductionStub = sinon.stub(deduction, "createDeduction");
 
       const client = buildClient();
@@ -171,7 +171,7 @@ describe("features/deduction", () => {
       deductionFeature(app);
       const handler = findHandler("message", /deduct/i);
 
-      sinon.stub(deduction, "isBalanceSufficent").resolves(true);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       sinon
         .stub(deduction, "createDeduction")
         .resolves({ _id: "DEDUCTION-123" });

--- a/test/features/join.js
+++ b/test/features/join.js
@@ -78,5 +78,22 @@ describe("features/join", () => {
       expect(text).to.include("An unknown error occured in Gratibot");
       expect(text).to.include("boom");
     });
+
+    it("should await conversations.join so a rejected promise is caught (regression for missing await)", async () => {
+      const { app, findHandler } = createMockApp();
+      joinFeature(app);
+      const handler = findHandler("event", "channel_created");
+
+      const join = sinon
+        .stub()
+        .rejects(new SlackError("conversations.join", "not_authed", "Nope"));
+      const client = buildClient(join);
+      const event = buildEvent();
+
+      await handler({ event, client });
+
+      expect(client.chat.postEphemeral.calledOnce).to.equal(true);
+      expect(client.chat.postEphemeral.firstCall.args[0].text).to.equal("Nope");
+    });
   });
 });

--- a/test/features/redeem.js
+++ b/test/features/redeem.js
@@ -69,7 +69,7 @@ describe("features/redeem", () => {
       sinon
         .stub(redeem, "getSelectedItemDetails")
         .returns({ itemName: "Sticker", itemCost: 5, kind: null });
-      sinon.stub(deduction, "isBalanceSufficent").resolves(true);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       sinon.stub(deduction, "createDeduction").resolves("DED-1");
 
       const client = buildClient();
@@ -109,7 +109,7 @@ describe("features/redeem", () => {
         itemCost: 0,
         kind: "liatrio-store",
       });
-      sinon.stub(deduction, "isBalanceSufficent").resolves(true);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       const createDeductionStub = sinon.stub(deduction, "createDeduction");
 
       const client = buildClient();
@@ -145,7 +145,7 @@ describe("features/redeem", () => {
         itemCost: 50,
         kind: null,
       });
-      sinon.stub(deduction, "isBalanceSufficent").resolves(true);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       const createDeductionStub = sinon
         .stub(deduction, "createDeduction")
         .resolves("DED-2");
@@ -181,7 +181,7 @@ describe("features/redeem", () => {
       sinon
         .stub(redeem, "getSelectedItemDetails")
         .returns({ itemName: "Sticker", itemCost: 500, kind: null });
-      sinon.stub(deduction, "isBalanceSufficent").resolves(false);
+      sinon.stub(deduction, "isBalanceSufficient").resolves(false);
       const createDeductionStub = sinon.stub(deduction, "createDeduction");
 
       const client = buildClient();

--- a/test/features/redeem.js
+++ b/test/features/redeem.js
@@ -86,6 +86,7 @@ describe("features/redeem", () => {
 
       expect(ack.calledOnce).to.equal(true);
       expect(deduction.createDeduction.calledOnce).to.equal(true);
+      expect(client.conversations.list.called).to.equal(false);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
       const text = client.chat.postMessage.firstCall.args[0].text;
       expect(text).to.include("<@Ucaller> has selected Sticker");
@@ -201,6 +202,53 @@ describe("features/redeem", () => {
       expect(client.chat.postEphemeral.firstCall.args[0].text).to.include(
         "Your current balance isn't high enough",
       );
+    });
+
+    it("should notify the user via postEphemeral when the redemption flow throws", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+
+      const client = buildClient();
+      client.conversations.open = sinon.stub().rejects(new Error("boom"));
+      const ack = sinon.stub().resolves();
+      const body = {
+        user: { id: "Ucaller" },
+        channel: { id: "Ddm" },
+        actions: [
+          { selected_option: { value: '{"name":"Sticker","cost":"5"}' } },
+        ],
+      };
+
+      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+
+      expect(client.chat.postEphemeral.calledOnce).to.equal(true);
+      const call = client.chat.postEphemeral.firstCall.args[0];
+      expect(call.channel).to.equal("Ddm");
+      expect(call.user).to.equal("Ucaller");
+      expect(call.text).to.include("Something went wrong");
+    });
+
+    it("should swallow a postEphemeral failure in the catch block without rejecting", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+
+      const client = buildClient();
+      client.conversations.open = sinon.stub().rejects(new Error("boom"));
+      client.chat.postEphemeral = sinon.stub().rejects(new Error("also boom"));
+      const ack = sinon.stub().resolves();
+      const body = {
+        user: { id: "Ucaller" },
+        channel: { id: "Ddm" },
+        actions: [
+          { selected_option: { value: '{"name":"Sticker","cost":"5"}' } },
+        ],
+      };
+
+      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+
+      expect(client.chat.postEphemeral.calledOnce).to.equal(true);
     });
   });
 });

--- a/test/integration/service/deduction.js
+++ b/test/integration/service/deduction.js
@@ -35,7 +35,7 @@ describe("integration: service/deduction", function () {
     sinon.restore();
   });
 
-  describe("isBalanceSufficent", () => {
+  describe("isBalanceSufficient", () => {
     it("should return true when the user's balance is at least the deduction value", async () => {
       await recognitionCollection.insertMany([
         {
@@ -64,7 +64,7 @@ describe("integration: service/deduction", function () {
         },
       ]);
 
-      const sufficient = await deduction.isBalanceSufficent("Ureceiver", 2);
+      const sufficient = await deduction.isBalanceSufficient("Ureceiver", 2);
       expect(sufficient).to.equal(true);
     });
 
@@ -78,7 +78,7 @@ describe("integration: service/deduction", function () {
         values: [],
       });
 
-      const sufficient = await deduction.isBalanceSufficent("Ureceiver", 50);
+      const sufficient = await deduction.isBalanceSufficient("Ureceiver", 50);
       expect(sufficient).to.equal(false);
     });
   });

--- a/test/service/deduction.js
+++ b/test/service/deduction.js
@@ -63,18 +63,18 @@ describe("deduction/balance", () => {
     });
   });
 
-  describe("isBalanceSufficent", () => {
+  describe("isBalanceSufficient", () => {
     it("should return true if balance is sufficient", async () => {
       sinon.stub(balance, "currentBalance").resolves(20);
 
-      const result = await deduction.isBalanceSufficent("testUser", 10);
+      const result = await deduction.isBalanceSufficient("testUser", 10);
       expect(result).to.be.true;
     });
 
     it("should return false if balance is not sufficient", async () => {
       sinon.stub(balance, "currentBalance").resolves(20);
 
-      const result = await deduction.isBalanceSufficent("testUser", 30);
+      const result = await deduction.isBalanceSufficient("testUser", 30);
       expect(result).to.be.false;
     });
   });


### PR DESCRIPTION
## Summary

Rolling PR for audit fixes. Starting with the HIGH-severity items; additional audit fixes (MEDIUM/LOW) may be appended to this branch before merge.

### Included so far

#### HIGH

- **H1** `features/join.js` — add missing `await` on `client.conversations.join()` so the surrounding `try/catch` actually handles rejected promises. Previously, any Slack API error was silently swallowed and the error dispatch was dead code.
- **H2** `features/redeem.js` — delete the dead `client.conversations.list()` call that was awaited but never used. It burned a Slack rate-limit slot on every redemption for nothing.
- **H3** `features/redeem.js` — notify the user via `chat.postEphemeral` when the redemption flow throws. The catch block was logging but leaving the user with a silent failure. The notification is wrapped in a best-effort nested catch so a notification failure cannot mask the original error.

#### LOW

- **L1** `service/deduction.js` — the `winston.debug` call inside `getDeductions` was tagged `func: "service.deduction.createDeduction"`, so log queries for `getDeductions` returned nothing and queries for `createDeduction` returned spurious hits. Tagged correctly.
- **L2** — rename `isBalanceSufficent` → `isBalanceSufficient` across `service/deduction.js`, `features/redeem.js`, `features/deduction.js`, and the service / feature / integration tests. The typo has been present since the function was introduced.
- **L3** `service/recognition.js` — use optional chaining so `multiplierRegex` is matched once against the message instead of twice (guard + branch of the original ternary). `multiplierFinding` is only consumed by a truthiness check one line later, so `undefined` vs `null` is irrelevant.
- **L4** `service/recognition.js` — use `===` when comparing receiver/giver Slack IDs in `gratitudeErrors`.
- **L5** `middleware/index.js` — use `===` in the `reactionMatches` emoji-slicing guard.
- **L10** `app.js` — delete the legacy `/gratibot` slash-command help path. `slack_app_manifest.yml` declares no `slash_commands`, so Slack never dispatches the `app.command(slashCommand, ...)` listener. `features/help.js` already serves help via DMs with a cleanly rewritten template. Removes `parseCommand`, the `app.command` handler, `errorMarkdown`, `helpMarkdown`, the unused destructured `./config` imports, and the section-divider comments that framed them. The `selcted` typo goes with the dead code (−145 lines).

### Tests

Each fix is covered by a regression test:
- New test in `test/features/join.js` using `.rejects(...)` (not `.throws(...)`) — this test would fail on `main` without the `await` fix.
- New `expect(client.conversations.list.called).to.equal(false)` in the redeem happy path.
- New tests that a `conversations.open` rejection produces a user-facing ephemeral message, and that a subsequent `postEphemeral` failure is swallowed rather than re-thrown.
- All existing deduction tests now reference the renamed `isBalanceSufficient` and continue to pass.
- L3/L4/L5 are covered by the existing recognition and middleware test suites.
- L10 has no test to add — the removed code was never executed.

## Test plan

- [x] `npm test` passes
- [x] `npm run lint` clean
- [ ] Manual smoke in nonprod after merge: trigger a redemption that fails (e.g. by restricting scopes) and confirm the ephemeral failure message is delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed channel join operations to properly wait for completion before proceeding.
  * Improved error handling during redemption failures with user notifications.
  * Corrected balance validation checks.

* **Removed Features**
  * Removed slash command functionality and related configuration settings.

* **Improvements**
  * Enhanced code quality with stricter equality checks and optional chaining.
  * Improved internal logging accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->