### PR TITLE
fix(redeem): look up reward from DB at redemption time

### DIFF
--- a/features/redeem.js
+++ b/features/redeem.js
@@ -34,15 +34,19 @@ async function redeemItem({ ack, body, context, client }) {
   await ack();
   const userID = body.user.id;
   try {
-    const result = await client.conversations.open({
-      token: context.botToken,
-      users: redeem.redeemNotificationUsers(userID),
-    });
-    const { itemName, itemCost, kind } = redeem.getSelectedItemDetails(
-      body.actions[0].selected_option.value,
-    );
+    const rewardId = body.actions[0].selected_option.value;
+    const reward = await redeem.fetchActiveRewardById(rewardId);
+    if (!reward) {
+      return client.chat.postEphemeral({
+        channel: body.channel.id,
+        user: userID,
+        text: "That reward is no longer available. Send `redeem` again to see the current list.",
+      });
+    }
 
-    if (!(await deduction.isBalanceSufficient(userID, itemCost))) {
+    const { name, cost, kind } = reward;
+
+    if (!(await deduction.isBalanceSufficient(userID, cost))) {
       return client.chat.postEphemeral({
         channel: body.channel.id,
         user: userID,
@@ -50,14 +54,19 @@ async function redeemItem({ ack, body, context, client }) {
       });
     }
 
-    let redemptionMessage = `<@${userID}> has selected ${itemName}`;
+    const result = await client.conversations.open({
+      token: context.botToken,
+      users: redeem.redeemNotificationUsers(userID),
+    });
+
+    let redemptionMessage = `<@${userID}> has selected ${name}`;
     if (kind === "liatrio-store") {
       redemptionMessage += `. Please provide the link of the item from the <https://liatrio.axomo.com/|Liatrio Store>.`;
     } else {
-      redemptionMessage += ` for ${itemCost} fistbumps.`;
+      redemptionMessage += ` for ${cost} fistbumps.`;
       const deductionID = await deduction.createDeduction(
         userID,
-        itemCost,
+        cost,
         redemptionMessage,
       );
       redemptionMessage += ` Deduction ID is \`${deductionID}\``;

--- a/service/redeem.js
+++ b/service/redeem.js
@@ -1,13 +1,24 @@
+const { ObjectId } = require("mongodb");
 const config = require("../config");
 const rewardCollection = require("../database/rewardCollection");
-
-const { redemptionAdmins } = config;
 
 function fetchActiveRewards() {
   return rewardCollection
     .find({ active: true })
     .sort({ sortOrder: 1, name: 1 })
     .toArray();
+}
+
+// Look up a single reward by id at redemption time, so an outdated dialog
+// cannot bypass admin edits to cost/name/kind or redeem a deactivated reward.
+async function fetchActiveRewardById(id) {
+  let objectId;
+  try {
+    objectId = new ObjectId(id);
+  } catch {
+    return null;
+  }
+  return rewardCollection.findOne({ _id: objectId, active: true });
 }
 
 function buildRedeemBlocks(rewards, currentBalance) {
@@ -61,17 +72,14 @@ function redeemItems(gratibotRewards) {
 function redeemSelector(gratibotRewards) {
   let options = [];
   for (let i = 0; i < gratibotRewards.length; i++) {
-    const item = {
-      name: `${gratibotRewards[i].name}`,
-      cost: `${gratibotRewards[i].cost}`,
-      kind: gratibotRewards[i].kind || null,
-    };
     options.push({
       text: {
         type: "plain_text",
         text: `${gratibotRewards[i].name}`,
       },
-      value: JSON.stringify(item),
+      // Serialize only the reward id; cost/name/kind are re-read from the DB
+      // at redemption time so an outdated dialog cannot apply a stale price.
+      value: String(gratibotRewards[i]._id),
     });
   }
   return {
@@ -110,7 +118,10 @@ function redeemSelector(gratibotRewards) {
   };
 }
 
-function redeemNotificationUsers(redeemingUser, admins = redemptionAdmins) {
+function redeemNotificationUsers(
+  redeemingUser,
+  admins = config.redemptionAdmins,
+) {
   let mpimGroup = `${redeemingUser}`;
   for (let i = 0; i < admins.length; i++) {
     mpimGroup += `, ${admins[i]}`;
@@ -118,21 +129,11 @@ function redeemNotificationUsers(redeemingUser, admins = redemptionAdmins) {
   return mpimGroup;
 }
 
-// Assumes value is json string
-function getSelectedItemDetails(selectedItem) {
-  const item = JSON.parse(selectedItem);
-  return {
-    itemName: item.name,
-    itemCost: item.cost,
-    kind: item.kind || null,
-  };
-}
-
 module.exports = {
   fetchActiveRewards,
+  fetchActiveRewardById,
   buildRedeemBlocks,
   redeemNotificationUsers,
-  getSelectedItemDetails,
   redeemHeader,
   redeemHelpText,
   redeemItems,

--- a/test/features/redeem.js
+++ b/test/features/redeem.js
@@ -61,32 +61,42 @@ describe("features/redeem", () => {
   });
 
   describe("redeemItem", () => {
-    it("should post a message including cost and deduction ID for a non-Liatrio Store item on the happy path", async () => {
+    function bodyWithRewardId(id) {
+      return {
+        user: { id: "Ucaller" },
+        channel: { id: "Ddm" },
+        actions: [{ selected_option: { value: id } }],
+      };
+    }
+
+    it("should look up the reward by id from the payload and use the DB cost/name for deduction", async () => {
       const { app, findHandler } = createMockApp();
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
-      sinon
-        .stub(redeem, "getSelectedItemDetails")
-        .returns({ itemName: "Sticker", itemCost: 5, kind: null });
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R1",
+        name: "Sticker",
+        cost: 5,
+        kind: null,
+      });
       sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       sinon.stub(deduction, "createDeduction").resolves("DED-1");
 
       const client = buildClient();
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          { selected_option: { value: '{"name":"Sticker","cost":"5"}' } },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R1"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(ack.calledOnce).to.equal(true);
+      expect(redeem.fetchActiveRewardById.calledWith("R1")).to.equal(true);
       expect(deduction.createDeduction.calledOnce).to.equal(true);
-      expect(client.conversations.list.called).to.equal(false);
+      expect(deduction.createDeduction.firstCall.args[1]).to.equal(5);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
       const text = client.chat.postMessage.firstCall.args[0].text;
       expect(text).to.include("<@Ucaller> has selected Sticker");
@@ -97,16 +107,44 @@ describe("features/redeem", () => {
       );
     });
 
-    it("should branch on kind === 'liatrio-store' (not on itemName) and skip createDeduction", async () => {
+    it("should bail with an ephemeral when the reward is no longer available", async () => {
       const { app, findHandler } = createMockApp();
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
-      // Note: itemName intentionally does NOT equal "Liatrio Store" —
-      // this asserts the branch uses kind, not the display name.
-      sinon.stub(redeem, "getSelectedItemDetails").returns({
-        itemName: "Some Other Display Name",
-        itemCost: 0,
+      sinon.stub(redeem, "fetchActiveRewardById").resolves(null);
+      const balanceStub = sinon.stub(deduction, "isBalanceSufficient");
+      const createDeductionStub = sinon.stub(deduction, "createDeduction");
+
+      const client = buildClient();
+      const ack = sinon.stub().resolves();
+
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("deleted-id"),
+        context: { botToken: "xoxb" },
+        client,
+      });
+
+      expect(balanceStub.called).to.equal(false);
+      expect(createDeductionStub.called).to.equal(false);
+      expect(client.conversations.open.called).to.equal(false);
+      expect(client.chat.postMessage.called).to.equal(false);
+      expect(client.chat.postEphemeral.calledOnce).to.equal(true);
+      expect(client.chat.postEphemeral.firstCall.args[0].text).to.include(
+        "no longer available",
+      );
+    });
+
+    it("should branch on kind === 'liatrio-store' from the DB row and skip createDeduction", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R2",
+        name: "Some Other Display Name",
+        cost: 0,
         kind: "liatrio-store",
       });
       sinon.stub(deduction, "isBalanceSufficient").resolves(true);
@@ -114,20 +152,13 @@ describe("features/redeem", () => {
 
       const client = buildClient();
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          {
-            selected_option: {
-              value:
-                '{"name":"Some Other Display Name","cost":"0","kind":"liatrio-store"}',
-            },
-          },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R2"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(createDeductionStub.called).to.equal(false);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
@@ -140,9 +171,10 @@ describe("features/redeem", () => {
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
-      sinon.stub(redeem, "getSelectedItemDetails").returns({
-        itemName: "Liatrio Store",
-        itemCost: 50,
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R3",
+        name: "Liatrio Store",
+        cost: 50,
         kind: null,
       });
       sinon.stub(deduction, "isBalanceSufficient").resolves(true);
@@ -152,19 +184,13 @@ describe("features/redeem", () => {
 
       const client = buildClient();
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          {
-            selected_option: {
-              value: '{"name":"Liatrio Store","cost":"50","kind":null}',
-            },
-          },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R3"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(createDeductionStub.calledOnce).to.equal(true);
       expect(client.chat.postMessage.calledOnce).to.equal(true);
@@ -173,30 +199,66 @@ describe("features/redeem", () => {
       expect(text).to.include("DED-2");
     });
 
+    it("should use the current DB cost, not any prior value, when an admin has edited the reward", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+
+      // Simulate the exact bug: payload arrived for a reward whose price has
+      // since changed. The flow must use the current DB cost (99), never the
+      // old cost the dialog might have rendered.
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R4",
+        name: "Mug",
+        cost: 99,
+        kind: null,
+      });
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
+      const createDeductionStub = sinon
+        .stub(deduction, "createDeduction")
+        .resolves("DED-3");
+
+      const client = buildClient();
+      const ack = sinon.stub().resolves();
+
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R4"),
+        context: { botToken: "xoxb" },
+        client,
+      });
+
+      expect(createDeductionStub.firstCall.args[1]).to.equal(99);
+      const text = client.chat.postMessage.firstCall.args[0].text;
+      expect(text).to.include("for 99 fistbumps");
+    });
+
     it("should post an ephemeral insufficient-balance warning when balance is too low", async () => {
       const { app, findHandler } = createMockApp();
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
-      sinon
-        .stub(redeem, "getSelectedItemDetails")
-        .returns({ itemName: "Sticker", itemCost: 500, kind: null });
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R5",
+        name: "Sticker",
+        cost: 500,
+        kind: null,
+      });
       sinon.stub(deduction, "isBalanceSufficient").resolves(false);
       const createDeductionStub = sinon.stub(deduction, "createDeduction");
 
       const client = buildClient();
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          { selected_option: { value: '{"name":"Sticker","cost":"500"}' } },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R5"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(createDeductionStub.called).to.equal(false);
+      expect(client.conversations.open.called).to.equal(false);
       expect(client.chat.postMessage.called).to.equal(false);
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       expect(client.chat.postEphemeral.firstCall.args[0].text).to.include(
@@ -209,18 +271,23 @@ describe("features/redeem", () => {
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R6",
+        name: "Sticker",
+        cost: 5,
+        kind: null,
+      });
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       const client = buildClient();
       client.conversations.open = sinon.stub().rejects(new Error("boom"));
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          { selected_option: { value: '{"name":"Sticker","cost":"5"}' } },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R6"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       const call = client.chat.postEphemeral.firstCall.args[0];
@@ -234,19 +301,24 @@ describe("features/redeem", () => {
       redeemFeature(app);
       const actionHandler = findHandler("action", { action_id: "redeem" });
 
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R7",
+        name: "Sticker",
+        cost: 5,
+        kind: null,
+      });
+      sinon.stub(deduction, "isBalanceSufficient").resolves(true);
       const client = buildClient();
       client.conversations.open = sinon.stub().rejects(new Error("boom"));
       client.chat.postEphemeral = sinon.stub().rejects(new Error("also boom"));
       const ack = sinon.stub().resolves();
-      const body = {
-        user: { id: "Ucaller" },
-        channel: { id: "Ddm" },
-        actions: [
-          { selected_option: { value: '{"name":"Sticker","cost":"5"}' } },
-        ],
-      };
 
-      await actionHandler({ ack, body, context: { botToken: "xoxb" }, client });
+      await actionHandler({
+        ack,
+        body: bodyWithRewardId("R7"),
+        context: { botToken: "xoxb" },
+        client,
+      });
 
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
     });

--- a/test/service/redeem.js
+++ b/test/service/redeem.js
@@ -25,28 +25,27 @@ describe("service/redeem", () => {
     });
   });
 
-  describe("getSelectedItemDetails", () => {
-    it("should parse name, cost, and kind from the payload", async () => {
-      const expectedItemDetails = {
-        itemName: "testName",
-        itemCost: 100,
-        kind: "liatrio-store",
-      };
-      const actualSelectedItemDetails = redeem.getSelectedItemDetails(
-        '{"name": "testName", "cost": 100, "kind": "liatrio-store"}',
-      );
-      expect(actualSelectedItemDetails).to.deep.eq(expectedItemDetails);
+  describe("fetchActiveRewardById", () => {
+    it("queries by _id and active flag when id is a valid ObjectId", async () => {
+      const findOne = sinon
+        .stub(rewardCollection, "findOne")
+        .resolves({ _id: "stub" });
+
+      await redeem.fetchActiveRewardById("507f1f77bcf86cd799439011");
+
+      expect(findOne.calledOnce).to.equal(true);
+      const filter = findOne.firstCall.args[0];
+      expect(filter.active).to.equal(true);
+      expect(String(filter._id)).to.equal("507f1f77bcf86cd799439011");
     });
 
-    it("should default kind to null when not present on the payload", async () => {
-      const actual = redeem.getSelectedItemDetails(
-        '{"name":"Sticker","cost":5}',
-      );
-      expect(actual).to.deep.eq({
-        itemName: "Sticker",
-        itemCost: 5,
-        kind: null,
-      });
+    it("returns null for an invalid ObjectId without hitting the collection", async () => {
+      const findOne = sinon.stub(rewardCollection, "findOne");
+
+      const result = await redeem.fetchActiveRewardById("not-an-object-id");
+
+      expect(result).to.equal(null);
+      expect(findOne.called).to.equal(false);
     });
   });
 
@@ -181,42 +180,44 @@ describe("service/redeem", () => {
   });
 
   describe("redeemSelector", () => {
-    it("serializes option.value including kind when present", async () => {
+    it("serializes option.value as the reward _id string", async () => {
       const gratibotRewards = [
         {
+          _id: "507f1f77bcf86cd799439011",
           name: "Liatrio Store",
-          cost: "0",
+          cost: 0,
           kind: "liatrio-store",
         },
       ];
 
       const block = redeem.redeemSelector(gratibotRewards);
       expect(block.accessory.options).to.have.length(1);
-      const parsed = JSON.parse(block.accessory.options[0].value);
-      expect(parsed).to.deep.equal({
-        name: "Liatrio Store",
-        cost: "0",
-        kind: "liatrio-store",
-      });
+      expect(block.accessory.options[0].value).to.equal(
+        "507f1f77bcf86cd799439011",
+      );
     });
 
-    it("serializes option.value with kind: null when absent", async () => {
-      const gratibotRewards = [{ name: "Sticker", cost: "5" }];
+    it("coerces non-string _id (e.g. ObjectId) to a string", async () => {
+      const gratibotRewards = [
+        {
+          _id: { toString: () => "507f1f77bcf86cd799439011" },
+          name: "Sticker",
+          cost: 5,
+        },
+      ];
 
       const block = redeem.redeemSelector(gratibotRewards);
-      const parsed = JSON.parse(block.accessory.options[0].value);
-      expect(parsed).to.deep.equal({
-        name: "Sticker",
-        cost: "5",
-        kind: null,
-      });
+      expect(block.accessory.options[0].value).to.equal(
+        "507f1f77bcf86cd799439011",
+      );
     });
 
     it("returns expected selector shell", async () => {
       const gratibotRewards = [
         {
+          _id: "id-1",
           name: "test",
-          cost: "10",
+          cost: 10,
         },
       ];
 


### PR DESCRIPTION
## Summary

- Fixes three bugs caused by embedding reward `name`, `cost`, and `kind` in the Slack option `value` and trusting the payload at redemption time:
  - **Stale price** — admin edits to `cost` between dialog render and click were ignored; the old price was applied to the deduction.
  - **Deactivated rewards still redeemable** — any already-rendered dialog could redeem a reward the admin had just deactivated.
  - **Stale name in admin DM + deduction record** — admin renames (e.g. typo fix, SKU change) didn't flow through to the audit trail.
- Now: `redeemSelector` serializes only the reward `_id`; `redeemItem` calls a new `fetchActiveRewardById` and uses the current DB `name`/`cost`/`kind`. Missing or inactive rewards surface a clear ephemeral: _"That reward is no longer available. Send `redeem` again to see the current list."_
- Drive-by: the admin DM (`conversations.open`) is now opened **after** validation passes, so invalid/unaffordable attempts don't create an MPIM.
- Drive-by: `redeemNotificationUsers` now reads `config.redemptionAdmins` at call time rather than via a module-load destructure, so `sinon.stub(config, "redemptionAdmins")` test overrides take effect.

### Known issues intentionally not addressed here

These were identified in review but are out of scope for this PR:

- TOCTOU race between `isBalanceSufficient` and `createDeduction` (needs atomic balance update).
- No `rewardId` stored on deduction records (audit trail still relies on free-text message).
- Stale dialog UX on the render side — a modal refactor would help but doesn't change correctness now that the payload is an `_id`.

## Test plan

- [x] `npm test` — 245 unit + 18 integration passing; 100% coverage on both `features/redeem.js` and `service/redeem.js`
- [x] `npm run lint` — clean
- [x] New regression test: assert `createDeduction` is called with the current DB `cost`, not any payload value
- [x] New test: reward returning `null` from `fetchActiveRewardById` skips balance check, skips MPIM open, and posts the "no longer available" ephemeral
- [x] Existing kind-branch, insufficient-balance, and error-handling tests rewritten against the new payload shape
- [x] Manual: render a redeem dialog in dev, have an admin edit a price, submit the stale dialog — confirm new price is applied
- [x] Manual: render a redeem dialog, have an admin deactivate the reward, submit the stale dialog — confirm ephemeral error is shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-time reward validation during the redemption process to ensure rewards remain available at redemption time.
  * Improved error messaging when rewards are no longer available.

* **Bug Fixes**
  * Enhanced cost accuracy by validating reward pricing against current database state at redemption time.

* **Tests**
  * Updated test coverage for reward validation, error handling, and pricing accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->