### PR TITLE
refactor: audit-driven cleanup of docs, naming, comments, and middleware

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@ lives in the service layer.
 | `metrics.js` | DM "metrics" | Show usage metrics |
 | `report.js` | DM "report" | Generate a recognition report |
 | `help.js` | DM "help" | Show help text |
-| `join.js` | `member_joined_channel` event | Welcome message when bot joins a channel |
+| `join.js` | `channel_created` event | Auto-join newly created public channels |
 
 All feature files are dynamically loaded at startup via `fs.readdirSync` in `app.js`.
 
@@ -77,7 +77,7 @@ native Collection object used directly by services.
 |---|---|---|
 | `db.js` | — | Connection singleton (`new MongoClient(config.mongo_url)`) |
 | `recognitionCollection.js` | `recognitions` | All `:fistbump:` recognition records |
-| `goldenRecognitionCollection.js` | `goldenrecognitions` | Golden fistbump transfer history |
+| `goldenRecognitionCollection.js` | `goldenrecognition` | Golden fistbump transfer history |
 | `deductionCollection.js` | `deductions` | Reward redemption and deduction records |
 
 ## Database Schema
@@ -91,12 +91,11 @@ native Collection object used directly by services.
   timestamp: Date,        // UTC timestamp
   message: String,        // Full message text
   channel: String,        // Slack channel ID
-  values: [String],       // Extracted #tags from the message
-  goldenFistbump: Boolean // true if this was a golden recognition
+  values: [String]        // Extracted #tags from the message
 }
 ```
 
-### `goldenrecognitions`
+### `goldenrecognition`
 
 ```javascript
 {
@@ -113,11 +112,11 @@ native Collection object used directly by services.
 
 ```javascript
 {
-  recognizee: String,   // User who redeemed
+  user: String,       // Slack ID of the redeemer
   timestamp: Date,
-  rewardName: String,   // Name of the redeemed item
-  rewardCost: Number,   // Cost in fistbumps
-  refunded: Boolean     // true after a refund is issued
+  refund: Boolean,    // true after a refund is issued
+  value: Number,      // Cost in fistbumps
+  message: String     // Human-readable redemption note
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,14 +136,14 @@ calling an HTTP endpoint. This means:
 
 Three helper middleware functions compose Bolt listener conditions:
 
-- `directMessage()` — returns a filter that passes only DM events
+- `directMessage` — a bare middleware that passes only DM events
 - `anyOf(...filters)` — logical OR over multiple Bolt filters
 - `reactionMatches(emoji)` — returns a filter that checks reaction emoji name
 
 Example usage in a feature:
 
 ```javascript
-app.message(directMessage(), /^balance/, async ({ message, say }) => { ... });
+app.message(directMessage, /^balance/, async ({ message, say }) => { ... });
 ```
 
 ### Block Kit

--- a/features/balance.js
+++ b/features/balance.js
@@ -28,7 +28,7 @@ async function respondToBalance({ message, client }) {
       error: userInfo.error,
     });
     await respondToUser(client, message, {
-      text: `Something went wrong while obtaining your balance. When retreiving user information from Slack, the API responded with the following error: ${userInfo.error}`,
+      text: `Something went wrong while obtaining your balance. When retrieving user information from Slack, the API responded with the following error: ${userInfo.error}`,
     });
     return;
   }

--- a/features/balance.js
+++ b/features/balance.js
@@ -38,7 +38,6 @@ async function respondToBalance({ message, client }) {
   const remainingToday = await balance.dailyGratitudeRemaining(
     message.user,
     userInfo.user.tz,
-    1,
   );
 
   const response = [

--- a/features/balance.js
+++ b/features/balance.js
@@ -7,7 +7,7 @@ const { respondToUser } = require("../service/messageutils");
 module.exports = function (app) {
   app.message(
     /balance/i,
-    anyOf(directMention, directMessage()),
+    anyOf(directMention, directMessage),
     respondToBalance,
   );
 };

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -30,7 +30,7 @@ async function respondToDeduction({ message, client }) {
       error: userInfo.error,
     });
     await respondToUser(client, message, {
-      text: `Something went wrong while creating your deduction. When retreiving user information from Slack, the API responded with the following error: ${userInfo.error}`,
+      text: `Something went wrong while creating your deduction. When retrieving user information from Slack, the API responded with the following error: ${userInfo.error}`,
     });
     return;
   }

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -9,7 +9,7 @@ const { respondToUser } = require("../service/messageutils");
 module.exports = function (app) {
   app.message(
     /deduct/i,
-    anyOf(directMention, directMessage()),
+    anyOf(directMention, directMessage),
     respondToDeduction,
   );
 };

--- a/features/help.js
+++ b/features/help.js
@@ -10,7 +10,7 @@ const { anyOf, directMessage } = require("../middleware");
 const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
-  app.message(/help/i, anyOf(directMention, directMessage()), respondToHelp);
+  app.message(/help/i, anyOf(directMention, directMessage), respondToHelp);
   app.message(/(thunderfury|Thunderfury)/, respondToEasterEgg);
 };
 

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -15,9 +15,9 @@ module.exports = function (app) {
 
 /*
  * Replies to a Slack user message with a leaderboard.
- * @param {object} bot A Botkit bot object.
- * @param {object} message A botkit message object, denoting the message triggering.
- *     this call.
+ * @param {object} args Bolt message listener args.
+ * @param {object} args.message The incoming Slack message event.
+ * @param {object} args.client A Slack WebClient instance.
  */
 async function respondToLeaderboard({ message, client }) {
   winston.info("@gratibot leaderboard Called", {
@@ -38,9 +38,11 @@ async function respondToLeaderboard({ message, client }) {
 
 /*
  * Replies to a Slack block_action on an existing leaderboard with updated info.
- * @param {object} bot A Botkit bot object.
- * @param {object} message A botkit message object, denoting the message triggering
- *     this call.
+ * @param {object} args Bolt action listener args.
+ * @param {Function} args.ack Acknowledges the action request.
+ * @param {object} args.body The full action payload.
+ * @param {object} args.action The triggered action (carries the selected time range in `value`).
+ * @param {Function} args.respond Replaces the original message with new content.
  */
 async function updateLeaderboardResponse({ ack, body, action, respond }) {
   await ack();

--- a/features/leaderboard.js
+++ b/features/leaderboard.js
@@ -7,7 +7,7 @@ const { respondToUser } = require("../service/messageutils");
 module.exports = function (app) {
   app.message(
     /leaderboard/i,
-    anyOf(directMessage(), directMention),
+    anyOf(directMessage, directMention),
     respondToLeaderboard,
   );
   app.action(/leaderboard-\d+/, updateLeaderboardResponse);

--- a/features/metrics.js
+++ b/features/metrics.js
@@ -7,7 +7,7 @@ const { respondToUser } = require("../service/messageutils");
 module.exports = function (app) {
   app.message(
     /metrics/i,
-    anyOf(directMessage(), directMention),
+    anyOf(directMessage, directMention),
     respondToMetrics,
   );
   app.action(/metrics-\d+/, updateMetricsResponse);

--- a/features/recognize.js
+++ b/features/recognize.js
@@ -45,13 +45,10 @@ async function respondToRecognitionMessage({ message, client }) {
       channel: message.channel,
       tags: recognition.gratitudeTagsIn(message.text),
       type: recognizeEmoji,
-      giver_in_receivers: false,
     };
-
-    // Check if the user who reacted is also a receiver
-    if (gratitude.receivers.some((r) => r.id === gratitude.giver.id)) {
-      gratitude.giver_in_receivers = true;
-    }
+    gratitude.giverInReceivers = gratitude.receivers.some(
+      (r) => r.id === gratitude.giver.id,
+    );
 
     await recognition.validateAndSendGratitude(gratitude);
 
@@ -121,13 +118,10 @@ async function respondToRecognitionReaction({ event, client }) {
       channel: event.channel,
       tags: recognition.gratitudeTagsIn(originalMessage.text),
       type: recognizeEmoji,
-      giver_in_receivers: false,
     };
-
-    // Check if the user who reacted is also a receiver
-    if (gratitude.receivers.some((r) => r.id === gratitude.giver.id)) {
-      gratitude.giver_in_receivers = true;
-    }
+    gratitude.giverInReceivers = gratitude.receivers.some(
+      (r) => r.id === gratitude.giver.id,
+    );
 
     await recognition.validateAndSendGratitude(gratitude);
 
@@ -170,6 +164,6 @@ async function messageReactedTo(client, message) {
   throw new SlackError(
     "conversations.replies",
     response.error,
-    `Something went wrong while sending recognition. When retreiving message information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
+    `Something went wrong while sending recognition. When retrieving message information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
   );
 }

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -7,11 +7,7 @@ const balance = require("../service/balance");
 const deduction = require("../service/deduction");
 
 module.exports = function (app) {
-  app.message(
-    /redeem/i,
-    anyOf(directMention, directMessage()),
-    respondToRedeem,
-  );
+  app.message(/redeem/i, anyOf(directMention, directMessage), respondToRedeem);
   app.action({ action_id: "redeem" }, redeemItem);
 };
 

--- a/features/refund.js
+++ b/features/refund.js
@@ -5,7 +5,7 @@ const refund = require("../service/refund");
 module.exports = function (app) {
   app.message(
     /refund/i,
-    anyOf(directMention, directMessage()),
+    anyOf(directMention, directMessage),
     refund.respondToRefund,
   );
 };

--- a/features/refund.js
+++ b/features/refund.js
@@ -1,6 +1,3 @@
-// Refund a redemption. This will delete the deduction of the associated ID
-// Ex: @gratibot refund DEDUCTION_ID
-// only redemption admins can execute this command
 const { directMention } = require("@slack/bolt");
 const { anyOf, directMessage } = require("../middleware");
 const refund = require("../service/refund");

--- a/features/report.js
+++ b/features/report.js
@@ -5,14 +5,11 @@ const { directMessage, anyOf } = require("../middleware");
 const { respondToUser } = require("../service/messageutils");
 
 module.exports = function (app) {
-  // Handle direct "report" command
   app.message(
     /^report(?:\s+<@([a-zA-Z0-9]+)>)?(?:\s+(\d+))?$/i,
-    anyOf(directMessage(), directMention),
+    anyOf(directMessage, directMention),
     respondToReport,
   );
-
-  // Handle button clicks for different time ranges
   app.action(/user-top-messages-\d+/, updateReportTimeRange);
 };
 
@@ -110,7 +107,6 @@ async function updateReportTimeRange({ ack, body, client, action, respond }) {
       parseInt(timeRange),
     );
 
-    // Update the message
     await respond({
       text: `Top recognized messages for <@${targetUserId}>`,
       blocks: blocks,

--- a/features/report.js
+++ b/features/report.js
@@ -1,4 +1,3 @@
-// Renders the service/report.js when using the command "report" in Slack
 const report = require("../service/report");
 const winston = require("../winston");
 const { directMention } = require("@slack/bolt");
@@ -23,24 +22,18 @@ async function respondToReport({ message, client }) {
     callingUser: message.user,
     slackMessage: message.text,
   });
-  // Check if a specific user was mentioned in the command
   const mentionMatch = message.text.match(/<@([a-zA-Z0-9]+)>/i);
   const targetUserId = mentionMatch ? mentionMatch[1] : message.user;
-
-  // Check if a time range was specified
   const timeRangeMatch = message.text.match(/\s+(\d+)\s*$/i);
 
   try {
-    // Get user info to verify the user exists
     const userInfo = await client.users.info({ user: targetUserId });
     if (!userInfo.ok) {
       throw new Error(`Error retrieving user info: ${userInfo.error}`);
     }
 
-    // Use specified time range or default to 180 days
     const timeRange = timeRangeMatch ? parseInt(timeRangeMatch[1]) : 180;
 
-    // Get the top messages and total recognitions for the user
     const topMessages = await report.getTopMessagesForUser(
       targetUserId,
       timeRange,
@@ -52,7 +45,6 @@ async function respondToReport({ message, client }) {
       userInfo.user.tz,
     );
 
-    // Create the blocks for the message - now awaiting since it's async
     const blocks = await report.createUserTopMessagesBlocks(
       targetUserId,
       topMessages,
@@ -93,16 +85,13 @@ async function updateReportTimeRange({ ack, body, client, action, respond }) {
   });
 
   try {
-    // Parse the action value to get the user ID and time range
     const [targetUserId, timeRange] = action.value.split(":");
 
-    // Get user info to get timezone
     const userInfo = await client.users.info({ user: targetUserId });
     if (!userInfo.ok) {
       throw new Error(`Error retrieving user info: ${userInfo.error}`);
     }
 
-    // Get the updated data
     const topMessages = await report.getTopMessagesForUser(
       targetUserId,
       parseInt(timeRange),
@@ -114,7 +103,6 @@ async function updateReportTimeRange({ ack, body, client, action, respond }) {
       userInfo.user.tz,
     );
 
-    // Create the updated blocks - now awaiting since it's async
     const blocks = await report.createUserTopMessagesBlocks(
       targetUserId,
       topMessages,

--- a/features/reward-admin.js
+++ b/features/reward-admin.js
@@ -10,11 +10,7 @@ const NO_ADMIN_ACCESS_MESSAGE = "You do not have admin access.";
 const ADMIN_MATCHER = /\badmin\b/i;
 
 module.exports = function (app) {
-  app.message(
-    ADMIN_MATCHER,
-    anyOf(directMention, directMessage()),
-    handleAdmin,
-  );
+  app.message(ADMIN_MATCHER, anyOf(directMention, directMessage), handleAdmin);
   app.action("reward_admin_open", handleOpenAction);
   app.action("reward_admin_add", handleAddAction);
   app.action("reward_admin_edit", handleEditAction);

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,12 +1,17 @@
-function directMessage() {
-  return async ({ message, next }) => {
-    if (message.channel_type === "im") {
-      await next();
-    }
-  };
+async function directMessage({ message, next }) {
+  if (message.channel_type === "im") {
+    await next();
+  }
 }
 
+/**
+ * Composes Bolt middleware with OR semantics.
+ * Returns a middleware that calls next() iff any of the provided middlewares
+ * would have. Short-circuits on the first pass.
+ */
 function anyOf(...funcs) {
+  // Swap-and-probe: replace Bolt's `next` with a flag setter so each child can
+  // be asked "would you pass?" without actually advancing the chain.
   return async (input) => {
     let anyPassed = false;
     let i = 0;
@@ -23,10 +28,12 @@ function anyOf(...funcs) {
 }
 
 function reactionMatches(emoji) {
+  if (emoji.startsWith(":") && emoji.endsWith(":")) {
+    emoji = emoji.slice(1, -1);
+  }
+  // Substring match (not equality): Slack encodes skin-tone reactions by
+  // suffixing the base name, e.g. "fistbump::skin-tone-2".
   return async ({ event, next }) => {
-    if (emoji[0] === ":" && emoji[emoji.length - 1] === ":") {
-      emoji = emoji.slice(1, -1);
-    }
     if (event.reaction.includes(emoji)) {
       await next();
     }

--- a/service/apiwrappers.js
+++ b/service/apiwrappers.js
@@ -9,7 +9,7 @@ async function userInfo(client, userId) {
   throw new SlackError(
     "users.info",
     response.error,
-    `Something went wrong while sending recognition. When retreiving user information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
+    `Something went wrong while sending recognition. When retrieving user information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
   );
 }
 

--- a/service/leaderboard.js
+++ b/service/leaderboard.js
@@ -14,12 +14,6 @@ const rank = [
   "10th",
 ];
 
-/*
- * Generates leaderboard message data in Slack's Block Kit style format.
- * @param {number} timeRange A number denoting the number of days of data
- *     the created leaderboard will include.
- * @return {object} A Block Kit style object, storing a Gratibot leaderboard.
- */
 async function createLeaderboardBlocks(timeRange) {
   let blocks = [];
 
@@ -61,10 +55,6 @@ async function goldenFistbumpHolder() {
 
 /* Block Kit Content */
 
-/*
- * Generates a Block Kit style object, storing a leaderboard header.
- * @return {object} A Block Kit style object, storing a leaderboard header.
- */
 function leaderboardHeader() {
   return {
     type: "section",
@@ -76,14 +66,6 @@ function leaderboardHeader() {
   };
 }
 
-/*
- * Generates a Block Kit style object, storing a Top Givers section
- *    header, and leaderboard entries for provided scores.
- * @param {Array<object>} giverScores An array of objects containing a user ID
- *     and a score.
- * @return {object} A Block Kit style object, storing a
- *     section header and leaderboard entries.
- */
 function topGivers(giverScores) {
   let markdown = "*Top Givers*\n\n";
   markdown += giverScores.map(leaderboardEntry).join("\n");
@@ -98,14 +80,6 @@ function topGivers(giverScores) {
   };
 }
 
-/*
- * Generates a Block Kit style object, storing a Top Receivers section
- *    header, and leaderboard entries for provided scores.
- * @param {Array<object>} receiverScores An array of objects containing a user
- *     ID and a score.
- * @return {object} A Block Kit style object, storing a
- *     section header and leaderboard entries.
- */
 function topReceivers(receiverScores) {
   let markdown = "*Top Receivers*\n\n";
   markdown += receiverScores.map(leaderboardEntry).join("\n");
@@ -120,14 +94,6 @@ function topReceivers(receiverScores) {
   };
 }
 
-/*
- * Generates a Block Kit style object, storing information denoting the
- *     timeRange of the generated leaderboard.
- * @param {number} timeRange A number denoting the number of days of data
- *     the created leaderboard includes.
- * @return {object} A Block Kit style objects, storing information denoting
- *     the timeRange of the generated leaderboard.
- */
 function timeRangeInfo(timeRange) {
   return {
     type: "context",
@@ -142,12 +108,6 @@ function timeRangeInfo(timeRange) {
   };
 }
 
-/*
- * Generates a Block Kit style object, containing buttons for generating
- *     a leaderboard with different timeRanges.
- * @return {object} A Block Kit style objects, containing buttons for generating
- *     a leaderboard with different timeRanges.
- */
 function timeRangeButtons() {
   return {
     type: "actions",
@@ -197,16 +157,6 @@ function timeRangeButtons() {
   };
 }
 
-/*
- * Generates a markdown string, containing a single leaderboard
- *     entry. Used with Array.map() to format score data.
- * @param {object} entry An object containing a userID and a corresponding
- *    score for a leaderboard entry.
- * @param {number} index A number denoting the rank a particular entry should
- *    be marked with in the leaderboard entry. (Ex: 1st, 2nd 3rd, etc)
- * @return {string} A string of markdown, storing a single leaderboard
- *     entry.
- */
 function leaderboardEntry(entry, index) {
   return `<@${entry.userID}> *${rank[index]} - Score:* ${entry.score}`;
 }
@@ -270,6 +220,8 @@ function convertToScores(leaderboardData) {
   let scores = [];
   for (const user in leaderboardData) {
     let userStats = leaderboardData[user];
+    // Diversity-weighted: subtracting total/unique penalises concentration, so
+    // N recognitions from N distinct users score ~N, but N from one user score ~1.
     let score =
       1 +
       userStats.totalRecognition -

--- a/service/messageutils.js
+++ b/service/messageutils.js
@@ -39,7 +39,7 @@ async function handleGenericError(client, message, error) {
   winston.error("Slack API returned an error response", {
     error,
   });
-  const userMessage = `An unknown error occured in Gratibot: ${error.message}`;
+  const userMessage = `An unknown error occurred in Gratibot: ${error.message}`;
   return respondToUser(client, message, { text: userMessage });
 }
 
@@ -47,7 +47,7 @@ async function sendNotificationToReceivers(client, gratitude) {
   for (let i = 0; i < gratitude.receivers.length; i++) {
     await client.chat.postMessage({
       channel: gratitude.receivers[i].id,
-      text: getRecieverMessage(gratitude),
+      text: getReceiverMessage(gratitude),
       ...(await recognition.receiverSlackNotification(
         gratitude,
         gratitude.receivers[i].id,
@@ -56,7 +56,7 @@ async function sendNotificationToReceivers(client, gratitude) {
   }
 }
 
-function getRecieverMessage(gratitude) {
+function getReceiverMessage(gratitude) {
   if (gratitude.type === goldenRecognizeEmoji) {
     return `You earned a ${goldenRecognizeEmoji}!!!`;
   }
@@ -69,5 +69,5 @@ module.exports = {
   handleGratitudeError,
   handleGenericError,
   sendNotificationToReceivers,
-  getRecieverMessage,
+  getReceiverMessage,
 };

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -132,7 +132,6 @@ async function doesUserHoldGoldenRecognition(userId, rec) {
 }
 
 async function getPreviousXDaysOfRecognition(timezone = null, days = null) {
-  //get only the entries from the specifc day from midnight
   let filter = {};
   if (days && timezone) {
     let userDate = moment(Date.now()).tz(timezone);
@@ -163,7 +162,7 @@ async function groupUsers(client, groupId) {
   throw new SlackError(
     "usergroups.users.list",
     response.error,
-    `Something went wrong while sending recognition. When retreiving usergroup information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
+    `Something went wrong while sending recognition. When retrieving usergroup information from Slack, the API responded with the following error: ${response.message} \n Recognition has not been sent.`,
   );
 }
 
@@ -203,7 +202,7 @@ async function isGratitudeAffordable(gratitude) {
     gratitude.giver.id,
     gratitude.giver.tz,
   );
-  if (gratitude.giver_in_receivers) {
+  if (gratitude.giverInReceivers) {
     gratitude.receivers = gratitude.receivers.filter(
       (x) => x.id !== gratitude.giver.id,
     );
@@ -258,7 +257,7 @@ async function goldenGratitudeErrors(gratitude) {
 async function giveGratitude(gratitude) {
   let results = [];
 
-  if (gratitude.giver_in_receivers) {
+  if (gratitude.giverInReceivers) {
     gratitude.receivers = gratitude.receivers.filter(
       (x) => x.id !== gratitude.giver.id,
     );
@@ -344,7 +343,7 @@ async function giverSlackNotification(gratitude) {
 
   // Notify the user if they are giving recognition to themselves when in the receiver list.
   let excludingGiver = "";
-  if (gratitude.giver_in_receivers) {
+  if (gratitude.giverInReceivers) {
     excludingGiver = ", excluding yourself";
   }
 

--- a/service/recognition.js
+++ b/service/recognition.js
@@ -20,7 +20,7 @@ const tagRegex = /#(\S+)/g;
 const generalEmojiRegex = /:([a-z-_']+):/g;
 const gratitudeEmojiRegex = new RegExp(config.recognizeEmoji, "g");
 const multiplierRegex = new RegExp(
-  `${config.recognizeEmoji}\\s*[Xx]([0-9]+)|[Xx]([0-9]+)\\s${config.recognizeEmoji}`,
+  `${config.recognizeEmoji}\\s*[Xx](?<count>[0-9]+)|[Xx](?<count>[0-9]+)\\s${config.recognizeEmoji}`,
 );
 
 // TODO Can we add a 'count' field to the recognition?
@@ -178,8 +178,7 @@ async function gratitudeReceiverIdsIn(client, text) {
 
 function gratitudeCountIn(text) {
   const emojiCount = (text.match(gratitudeEmojiRegex) || []).length;
-  const multiplierFinding = text.match(multiplierRegex)?.filter(Boolean);
-  const multiplier = multiplierFinding ? multiplierFinding[1] : 1;
+  const multiplier = Number(text.match(multiplierRegex)?.groups.count ?? 1);
   return emojiCount * multiplier;
 }
 

--- a/service/refund.js
+++ b/service/refund.js
@@ -17,7 +17,7 @@ async function respondToRefund({ message, client, admins = redemptionAdmins }) {
     await client.chat.postMessage({
       channel: message.channel,
       user: message.user,
-      text: "Refund Successfully given",
+      text: "Refund successfully given",
     });
   } else {
     await client.chat.postMessage({

--- a/service/report.js
+++ b/service/report.js
@@ -1,4 +1,3 @@
-// Reaches out to the Mongo DB database to get the top ten messages for a specified user
 const winston = require("../winston");
 const moment = require("moment-timezone");
 const recognitionCollection = require("../database/recognitionCollection");
@@ -23,14 +22,12 @@ async function getTopMessagesForUser(
     timezone,
   });
 
-  // Calculate the date range
   const userDate = moment(Date.now()).tz(timezone);
   const startDate = userDate
     .clone()
     .subtract(timeRange - 1, "days")
     .startOf("day");
 
-  // Create the filter for the date range and user
   const filter = {
     recognizee: userId,
     timestamp: {
@@ -39,32 +36,23 @@ async function getTopMessagesForUser(
   };
 
   try {
-    // Get top 10 messages for this user using MongoDB aggregation
     const topMessages = await recognitionCollection
       .aggregate([
-        // Match only recognitions for this user in the time period
         { $match: filter },
-        // Group by message and count occurrences
         {
           $group: {
             _id: "$message",
             count: { $sum: 1 },
-            // Keep the first timestamp for reference
             firstTimestamp: { $first: "$timestamp" },
-            // Keep a sample channel for reference
             channel: { $first: "$channel" },
-            // Collect all recognizers who gave this recognition
             recognizers: { $addToSet: "$recognizer" },
           },
         },
-        // Sort by count in descending order
         { $sort: { count: -1 } },
-        // Limit to top 10
         { $limit: 10 },
       ])
       .toArray();
 
-    // Format the results
     return topMessages.map((msg) => {
       return {
         message: msg._id,
@@ -97,14 +85,12 @@ async function getTotalRecognitionsForUser(
   timeRange = 30,
   timezone = "America/Los_Angeles",
 ) {
-  // Calculate the date range
   const userDate = moment(Date.now()).tz(timezone);
   const startDate = userDate
     .clone()
     .subtract(timeRange - 1, "days")
     .startOf("day");
 
-  // Create the filter for the date range and user
   const filter = {
     recognizee: userId,
     timestamp: {
@@ -140,7 +126,6 @@ async function createUserTopMessagesBlocks(
 ) {
   const blocks = [];
 
-  // Add header
   blocks.push({
     type: "header",
     text: {
@@ -150,7 +135,6 @@ async function createUserTopMessagesBlocks(
     },
   });
 
-  // Add user info
   blocks.push({
     type: "section",
     text: {
@@ -159,12 +143,10 @@ async function createUserTopMessagesBlocks(
     },
   });
 
-  // Add divider
   blocks.push({
     type: "divider",
   });
 
-  // If no data, show a message
   if (topMessages.length === 0) {
     blocks.push({
       type: "section",
@@ -174,7 +156,6 @@ async function createUserTopMessagesBlocks(
       },
     });
   } else {
-    // Add top messages section
     blocks.push({
       type: "section",
       text: {
@@ -183,7 +164,6 @@ async function createUserTopMessagesBlocks(
       },
     });
 
-    // Add each message with its count
     topMessages.forEach((msg, index) => {
       const recognizersText =
         msg.recognizers.length > 3
@@ -200,7 +180,6 @@ async function createUserTopMessagesBlocks(
     });
   }
 
-  // Add time range buttons
   blocks.push({
     type: "actions",
     block_id: "userTopMessagesTimeRange",

--- a/test/features/golden-recognize.js
+++ b/test/features/golden-recognize.js
@@ -164,7 +164,7 @@ describe("features/golden-recognize", () => {
 
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       const text = client.chat.postEphemeral.firstCall.args[0].text;
-      expect(text).to.include("An unknown error occured in Gratibot");
+      expect(text).to.include("An unknown error occurred in Gratibot");
       expect(text).to.include("unexpected");
     });
   });

--- a/test/features/join.js
+++ b/test/features/join.js
@@ -75,7 +75,7 @@ describe("features/join", () => {
 
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       const text = client.chat.postEphemeral.firstCall.args[0].text;
-      expect(text).to.include("An unknown error occured in Gratibot");
+      expect(text).to.include("An unknown error occurred in Gratibot");
       expect(text).to.include("boom");
     });
 

--- a/test/features/recognize.js
+++ b/test/features/recognize.js
@@ -74,7 +74,7 @@ describe("features/recognize", () => {
       const gratitude = recognition.validateAndSendGratitude.firstCall.args[0];
       expect(gratitude.giver.id).to.equal("Ugiver");
       expect(gratitude.receivers.map((r) => r.id)).to.deep.equal(["Ureceiver"]);
-      expect(gratitude.giver_in_receivers).to.equal(false);
+      expect(gratitude.giverInReceivers).to.equal(false);
       expect(gratitude.channel).to.equal("Cchannel");
       expect(gratitude.type).to.equal(config.recognizeEmoji);
 
@@ -84,7 +84,7 @@ describe("features/recognize", () => {
       expect(reactionArgs.timestamp).to.equal("1700000000.000100");
     });
 
-    it("should flag giver_in_receivers when the giver also appears in the receiver list", async () => {
+    it("should flag giverInReceivers when the giver also appears in the receiver list", async () => {
       const { app, findHandler } = createMockApp();
       recognizeFeature(app);
       const messageHandler = findHandler("message", config.recognizeEmoji);
@@ -116,7 +116,7 @@ describe("features/recognize", () => {
       await messageHandler({ message, client });
 
       const gratitude = recognition.validateAndSendGratitude.firstCall.args[0];
-      expect(gratitude.giver_in_receivers).to.equal(true);
+      expect(gratitude.giverInReceivers).to.equal(true);
     });
 
     it("should route SlackError through handleSlackError and not react to the message", async () => {
@@ -201,7 +201,7 @@ describe("features/recognize", () => {
       expect(client.reactions.add.called).to.equal(false);
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       const text = client.chat.postEphemeral.firstCall.args[0].text;
-      expect(text).to.include("An unknown error occured in Gratibot");
+      expect(text).to.include("An unknown error occurred in Gratibot");
       expect(text).to.include("unexpected-boom");
     });
 
@@ -364,7 +364,7 @@ describe("features/recognize", () => {
       );
     });
 
-    it("should set giver_in_receivers when the reactor is also a receiver", async () => {
+    it("should set giverInReceivers when the reactor is also a receiver", async () => {
       const { app, findHandler } = createMockApp();
       recognizeFeature(app);
       const reactionHandler = findHandler("event", "reaction_added");
@@ -385,7 +385,7 @@ describe("features/recognize", () => {
       await reactionHandler({ event, client });
 
       const gratitude = recognition.validateAndSendGratitude.firstCall.args[0];
-      expect(gratitude.giver_in_receivers).to.equal(true);
+      expect(gratitude.giverInReceivers).to.equal(true);
     });
   });
 });

--- a/test/middleware/index.js
+++ b/test/middleware/index.js
@@ -7,14 +7,14 @@ describe("middleware/index", () => {
     it('should call next if message channel type is "im"', async () => {
       const next = sinon.spy();
       const message = { channel_type: "im" };
-      await directMessage()({ message, next });
+      await directMessage({ message, next });
       expect(next.calledOnce).to.be.true;
     });
 
     it('should not call next if message channel type is not "im"', async () => {
       const next = sinon.spy();
       const message = { channel_type: "not_im" };
-      await directMessage()({ message, next });
+      await directMessage({ message, next });
       expect(next.called).to.be.false;
     });
   });

--- a/test/service/messageutils.js
+++ b/test/service/messageutils.js
@@ -161,7 +161,7 @@ describe("service/messageutils", () => {
       sinon.assert.calledWith(testClient.chat.postEphemeral, {
         channel: testMessage.channel,
         user: testMessage.user,
-        text: "An unknown error occured in Gratibot: test error",
+        text: "An unknown error occurred in Gratibot: test error",
       });
     });
   });
@@ -206,13 +206,13 @@ describe("service/messageutils", () => {
     });
   });
 
-  describe("getRecieverMessage", () => {
+  describe("getReceiverMessage", () => {
     it("should get golden fistbump message", () => {
       const testGratitude = {
         type: goldenRecognizeEmoji,
       };
       const actualReceiverMessage =
-        messageutils.getRecieverMessage(testGratitude);
+        messageutils.getReceiverMessage(testGratitude);
       expect(actualReceiverMessage).to.eq(
         `You earned a ${goldenRecognizeEmoji}!!!`,
       );
@@ -223,7 +223,7 @@ describe("service/messageutils", () => {
         type: recognizeEmoji,
       };
       const actualReceiverMessage =
-        messageutils.getRecieverMessage(testGratitude);
+        messageutils.getReceiverMessage(testGratitude);
       expect(actualReceiverMessage).to.eq(`You earned a ${recognizeEmoji}.`);
     });
   });

--- a/test/service/recognition.js
+++ b/test/service/recognition.js
@@ -691,7 +691,7 @@ describe("service/recognition", () => {
       expect(result).to.be.false;
     });
 
-    it("should remove the giver from receivers if giver_in_receivers is true", async () => {
+    it("should remove the giver from receivers if giverInReceivers is true", async () => {
       const gratitude = {
         giver: {
           id: "Giver",
@@ -705,7 +705,7 @@ describe("service/recognition", () => {
         trimmedMessage: "  Test Message 1234567890",
         channel: "TestChannel",
         tags: [],
-        giver_in_receivers: true,
+        giverInReceivers: true,
       };
       const dailyGratitudeRemaining = 10;
       balanceStub
@@ -735,7 +735,7 @@ describe("service/recognition", () => {
         trimmedMessage: "  Test Message 1234567890",
         channel: "TestChannel",
         tags: [],
-        giver_in_receivers: true,
+        giverInReceivers: true,
       };
       const dailyGratitudeRemaining = 2;
       balanceStub

--- a/test/service/refund.js
+++ b/test/service/refund.js
@@ -30,7 +30,7 @@ describe("service/refund", () => {
       sinon.assert.calledWith(testClient.chat.postMessage, {
         channel: testMessage.channel,
         user: testMessage.user,
-        text: "Refund Successfully given",
+        text: "Refund successfully given",
       });
     });
 


### PR DESCRIPTION
## Summary

An audit pass over the codebase — five thematic commits, each reviewable in isolation. No behavior changes; release impact is zero (all commit types outside `feat`/`fix`/`perf` per the project's `.releaserc.js`).

### Commits

1. **`docs(architecture): correct schema and event descriptions`** — Align `docs/ARCHITECTURE.md` with the code: `join.js` registers `channel_created` (not `member_joined_channel`); the golden collection is `goldenrecognition` (singular); `recognitions` has no `goldenFistbump` field; `deductions` uses `user`, `refund`, `value`, `message`.

2. **`refactor: correct typos and identifier casing`** — `retreiving` → `retrieving` (×5), `occured` → `occurred`, `Refund Successfully` → `Refund successfully`, `getRecieverMessage` → `getReceiverMessage`, `giver_in_receivers` → `giverInReceivers` (camelCase per project convention). Collapses the false-init + conditional-set pattern around `giverInReceivers` into a single `.some()` assignment. Tests updated.

3. **`chore: remove restatement comments and add WHY comments`** — Drops WHAT-level inline comments across `features/report.js`, `service/report.js`, and `service/leaderboard.js`. Replaces stale Botkit JSDoc on `features/leaderboard.js` with Bolt-accurate shapes. Adds a short WHY comment on `service/leaderboard.js#convertToScores` explaining the diversity-weighted formula.

4. **`refactor: drop dead arg and use named regex groups`** — Removes trailing `1` from `balance.dailyGratitudeRemaining(...)` (signature takes `(userId, tz)`). Rewrites `multiplierRegex` with duplicate named capture groups `(?<count>…)` (ES2025 / Node 22+) and reads `match.groups.count ?? 1`, replacing `?.filter(Boolean)[1]` indexing that depended on which alternation matched.

5. **`refactor(middleware): simplify directMessage and document intent`** — Converts `directMessage` from a zero-arg factory to a bare middleware (every caller immediately invoked it); updates 9 feature call sites and the test. Adds JSDoc on `anyOf` describing the OR semantics plus an inline comment explaining the swap-and-probe mechanism. Cleans up `reactionMatches`: strip colons at factory time instead of per-call, use `startsWith`/`endsWith`, and document why the match is `.includes()` (Slack encodes skin-tone reactions as `fistbump::skin-tone-2`).

## Test plan

- [x] `npm test` — 245 + 18 passing
- [x] `npm run lint` — clean
- [x] Manual smoke: DM a dev bot with `balance`, `help`, `leaderboard`, `redeem`, `report` and confirm each still routes
- [x] Manual smoke: give a `:fistbump: x3` recognition and confirm the named-group multiplier parses correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected multiple spelling errors in error messages throughout the app ("retrieved" instead of "retreived", "occurred" instead of "occured")
  * Fixed capitalization in the refund confirmation message ("successfully given" instead of "Successfully given")

* **Documentation**
  * Updated architecture documentation to reflect changes to database collections, schema field names, and event handling logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->