### PR TITLE
ci: persist prod terraform plan as artifact and step summary

### DIFF
--- a/.github/workflows/apply-prod.yml
+++ b/.github/workflows/apply-prod.yml
@@ -51,14 +51,30 @@ jobs:
         uses: gruntwork-io/terragrunt-action@53dbdc2c3d43e82bf3bae10b734a968196442bec # v3.2.0
       - name: Plan Gratibot prod deployment
         working-directory: infra/terragrunt/prod/gratibot/
+        shell: bash
         run: |
-          terragrunt plan
+          set -eo pipefail
+          terragrunt plan -no-color -out="$PWD/tfplan" 2>&1 | tee plan.txt
+          {
+            echo "## Terraform plan for prod"
+            echo ""
+            echo '```terraform'
+            cat plan.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_PROD_SUBSCRIPTION_ID }}
           ARM_USE_OIDC: true
           TF_VAR_gratibot_image: "${{ env.IMAGE_PATH }}:${{ needs.promote.outputs.docker_tag }}"
+      - name: Upload plan artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: tfplan
+          path: infra/terragrunt/prod/gratibot/tfplan
+          retention-days: 7
+          if-no-files-found: error
   apply:
     name: "Terraform Prod Apply"
     runs-on: ubuntu-latest
@@ -72,10 +88,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install OpenTofu and Terragrunt
         uses: gruntwork-io/terragrunt-action@53dbdc2c3d43e82bf3bae10b734a968196442bec # v3.2.0
+      - name: Download plan artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: tfplan
+          path: infra/terragrunt/prod/gratibot/
       - name: Deploy Gratibot to Prod
         working-directory: infra/terragrunt/prod/gratibot/
         run: |
-          terragrunt apply --non-interactive -auto-approve
+          terragrunt apply --non-interactive "$PWD/tfplan"
         env:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary
- Render the prod `terragrunt plan` output to `$GITHUB_STEP_SUMMARY` in the `plan` job so reviewers see the plan inline on the workflow run page (one click from the manual approval prompt) instead of having to dig back through the prior job's logs.
- Save the binary plan as a `tfplan` artifact and have the `apply` job consume it via `terragrunt apply ./tfplan`, so the production apply executes the exact plan that was approved rather than implicitly re-planning at apply time. If state has drifted between approval and apply, terraform will refuse rather than silently apply something different from what was reviewed.
- Artifact is scoped to the workflow run (download-artifact@v4 default), and the existing `tf-prod` concurrency group already serializes plan/apply across runs, so concurrent releases cannot cross-pollinate plans.
- This is a `ci:`-typed change and will not trigger a semantic-release; the prod workflow itself is gated on a release event, so this PR landing won't deploy itself to prod. The first prod run after the next release will exercise the new flow.

## Test plan
- [ ] Trigger a release (or wait for the next one) and confirm the `plan` job's run page shows a "Terraform plan for prod" section under its Summary tab with the rendered plan
- [ ] Confirm the `tfplan` artifact appears in the run's Artifacts list
- [ ] Approve the `prod` environment and confirm the `apply` job downloads the artifact and applies it without re-planning
- [ ] Confirm a `ci:`-only merge does not produce a new GitHub release (semantic-release should exit without releasing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced production deployment workflow to save and review deployment plans before applying, with improved visibility through GitHub step summaries and artifact storage for deployment plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->