### PR TITLE
feat: add Stadium points redemption

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,10 @@ const express = require("express");
 const webserver = express();
 const winston = require("./winston");
 const client = require("./database/db");
+const config = require("./config");
+const stadium = require("./service/stadium");
+
+const RECONCILIATION_INTERVAL_MS = 60 * 1000;
 
 const app = new App({
   token: process.env.BOT_USER_OAUTH_ACCESS_TOKEN,
@@ -63,6 +67,83 @@ webserver.get("/health", async (req, res) => {
   winston.debug("Health check passed");
 });
 
+async function notifyReconciliation(reconciliation) {
+  const notifications = [];
+  for (const record of reconciliation.refundedRecords) {
+    notifications.push(
+      app.client.chat.postMessage({
+        channel: record.user,
+        text: `Your interrupted Stadium redemption \`${record._id}\` did not reach Stadium. Your fistbumps were restored.`,
+      }),
+    );
+  }
+  for (const record of reconciliation.needsReviewRecords) {
+    notifications.push(
+      app.client.chat.postMessage({
+        channel: record.user,
+        text: `Your interrupted Stadium redemption \`${record._id}\` has an uncertain result. Your fistbumps remain held while an admin reviews it.`,
+      }),
+    );
+  }
+  const results = await Promise.allSettled(notifications);
+  const failed = results.filter((result) => result.status === "rejected");
+  if (failed.length) {
+    winston.error("Some Stadium reconciliation notifications failed", {
+      func: "app.notifyReconciliation",
+      failedCount: failed.length,
+    });
+  }
+}
+
+async function notifyOutstandingStadiumReviews() {
+  const claims = await stadium.claimReviewNotifications();
+  for (const { record, claimId } of claims) {
+    const results = await Promise.allSettled(
+      config.redemptionAdmins.map((admin) =>
+        app.client.chat.postMessage({
+          channel: admin,
+          text: `Stadium redemption \`${record._id}\` for <@${record.user}> needs review. Run \`stadium review\`, then either \`stadium resolve ${record._id} fulfilled\` to confirm fulfillment or \`stadium resolve ${record._id} refund\` to restore the fistbumps.`,
+        }),
+      ),
+    );
+    const delivered = results.some((result) => result.status === "fulfilled");
+    const failedCount = results.filter(
+      (result) => result.status === "rejected",
+    ).length;
+    if (!delivered || failedCount) {
+      winston.error("Some Stadium review admin notifications failed", {
+        func: "app.notifyOutstandingStadiumReviews",
+        redemptionId: record._id,
+        failedCount,
+        adminCount: config.redemptionAdmins.length,
+      });
+    }
+    await stadium.completeReviewNotification(record._id, claimId, delivered);
+  }
+  return claims.length;
+}
+
+async function runStadiumReconciliation() {
+  const reconciliation = await stadium.reconcilePending();
+  await notifyReconciliation(reconciliation);
+  const adminNotifications = await notifyOutstandingStadiumReviews();
+  const details = {
+    func: "app.runStadiumReconciliation",
+    refunded: reconciliation.refunded,
+    needsReview: reconciliation.needsReview,
+    adminNotifications,
+  };
+  if (
+    reconciliation.refunded ||
+    reconciliation.needsReview ||
+    adminNotifications
+  ) {
+    winston.info("Stadium redemption reconciliation completed", details);
+  } else {
+    winston.debug("Stadium redemption reconciliation completed", details);
+  }
+}
+
 (async () => {
   try {
     await client.connect();
@@ -76,8 +157,25 @@ webserver.get("/health", async (req, res) => {
         require("./features/" + file)(app);
       });
 
+    try {
+      await runStadiumReconciliation();
+    } catch (error) {
+      winston.error("Startup Stadium reconciliation failed", {
+        func: "app.startupReconciliation",
+        error: error.message,
+      });
+    }
     await app.start();
     webserver.listen(process.env.PORT || 3000);
+    const reconciliationTimer = setInterval(() => {
+      runStadiumReconciliation().catch((error) => {
+        winston.error("Periodic Stadium reconciliation failed", {
+          func: "app.reconciliationTimer",
+          error: error.message,
+        });
+      });
+    }, RECONCILIATION_INTERVAL_MS);
+    reconciliationTimer.unref();
 
     winston.info("⚡️ Bolt app is running!");
   } catch (e) {

--- a/config.js
+++ b/config.js
@@ -44,6 +44,7 @@ const stadiumMaximumFistbumps = process.env.STADIUM_MAX_FISTBUMPS?.trim();
 
 config.stadium = {
   enabled: process.env.STADIUM_ENABLED === "true",
+  emailSource: process.env.STADIUM_EMAIL_SOURCE || "modal",
   apiBaseUrl:
     process.env.STADIUM_API_BASE_URL ||
     "https://api.preprod.bystadium.com/api/v2",

--- a/config.js
+++ b/config.js
@@ -40,4 +40,26 @@ config.redemptionAdmins = process.env.REDEMPTION_ADMINS?.split(",") || [
   "U04666K57CP", // Danielle Johnson
 ];
 
+const stadiumMaximumFistbumps = process.env.STADIUM_MAX_FISTBUMPS?.trim();
+
+config.stadium = {
+  enabled: process.env.STADIUM_ENABLED === "true",
+  apiBaseUrl:
+    process.env.STADIUM_API_BASE_URL ||
+    "https://api.preprod.bystadium.com/api/v2",
+  clientId: process.env.STADIUM_CLIENT_ID,
+  clientSecret: process.env.STADIUM_CLIENT_SECRET,
+  storeNumber: process.env.STADIUM_STORE_NUMBER,
+  storeUrl: process.env.STADIUM_STORE_URL,
+  paymentMethod: process.env.STADIUM_PAYMENT_METHOD,
+  billingCountry: process.env.STADIUM_BILLING_COUNTRY,
+  billingZipcode: process.env.STADIUM_BILLING_ZIPCODE,
+  fistbumpsPerUnit: Number(process.env.STADIUM_FISTBUMPS_PER_UNIT || 1),
+  pointsPerUnit: Number(process.env.STADIUM_POINTS_PER_UNIT || 1),
+  minimumFistbumps: Number(process.env.STADIUM_MIN_FISTBUMPS || 1),
+  maximumFistbumps: stadiumMaximumFistbumps
+    ? Number(stadiumMaximumFistbumps)
+    : null,
+};
+
 module.exports = config;

--- a/database/deductionCollection.js
+++ b/database/deductionCollection.js
@@ -4,5 +4,10 @@ const deductionCollection = client.db().collection("deduction");
 deductionCollection.createIndex({ user: 1 });
 deductionCollection.createIndex({ timestamp: 1 });
 deductionCollection.createIndex({ refund: 1 });
+deductionCollection.createIndex({
+  source: 1,
+  status: 1,
+  "reviewNotification.nextAttemptAt": 1,
+});
 
 module.exports = deductionCollection;

--- a/database/deductionLockCollection.js
+++ b/database/deductionLockCollection.js
@@ -1,0 +1,3 @@
+const client = require("./db");
+
+module.exports = client.db().collection("deductionLocks");

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,6 +42,7 @@ lives in the service layer.
 | `redeem.js` | DM "redeem" | Open reward redemption dialog |
 | `deduction.js` | DM "deduction" | Admin: record a reward deduction |
 | `refund.js` | DM "refund DEDUCTIONID" | Admin: refund a deduction |
+| `stadium-redeem.js` | Stadium reward button/modal; DM "stadium review/resolve" | Exchange fistbumps for Stadium points and administer uncertain redemptions |
 | `metrics.js` | DM "metrics" | Show usage metrics |
 | `report.js` | DM "report" | Generate a recognition report |
 | `help.js` | DM "help" | Show help text |
@@ -62,6 +63,7 @@ via the wrappers in `service/apiwrappers.js`).
 | `deduction.js` | Record and query reward deductions |
 | `redeem.js` | Build redemption UI (Slack Block Kit) and process redemption requests |
 | `refund.js` | Process refunds; reverse deduction records |
+| `stadium.js` | Validate, dispatch, reconcile, and resolve Stadium point redemptions |
 | `leaderboard.js` | Aggregate top givers and receivers |
 | `metrics.js` | Compute recognition counts over time windows |
 | `report.js` | Generate formatted recognition reports |
@@ -80,6 +82,7 @@ native Collection object used directly by services.
 | `recognitionCollection.js` | `recognitions` | All `:fistbump:` and `:self-fistbump:` recognition records (self-fistbumps have `recognizer === recognizee`) |
 | `goldenRecognitionCollection.js` | `goldenrecognition` | Golden fistbump transfer history |
 | `deductionCollection.js` | `deductions` | Reward redemption and deduction records |
+| `deductionLockCollection.js` | `deductionLocks` | Per-user leases that serialize balance checks and deductions |
 
 ## Database Schema
 
@@ -113,11 +116,43 @@ native Collection object used directly by services.
 
 ```javascript
 {
-  user: String,       // Slack ID of the redeemer
+  _id: ObjectId | String, // ObjectId normally; deterministic "stadium:<team>:<view>" for Stadium
+  user: String,           // Slack ID of the redeemer
   timestamp: Date,
-  refund: Boolean,    // true after a refund is issued
-  value: Number,      // Cost in fistbumps
-  message: String     // Human-readable redemption note
+  refund: Boolean,        // true after a refund is issued
+  value: Number,          // Cost in fistbumps
+  message: String,        // Human-readable note for ordinary deductions
+
+  // Stadium deductions additionally contain:
+  source: "stadium",
+  status: "reserved" | "sending" | "fulfilled" | "failed" | "needs_review" | "refunded",
+  corporateEmail: String,
+  stadiumPoints: Number,
+  ratio: { fistbumpsPerUnit: Number, pointsPerUnit: Number },
+  updatedAt: Date,
+  stadium: Object,        // Provider response or error details, when available
+  resolution: Object,     // Admin, action, and timestamp after manual resolution
+  lateConfirmationAt: Date,
+  reviewNotification: {   // Durable, leased admin-notification delivery state
+    nextAttemptAt: Date,
+    claimId: String,
+    claimUntil: Date,
+    lastAttemptAt: Date,
+    notifiedAt: Date
+  }
+}
+```
+
+### `deductionLocks`
+
+```javascript
+{
+  _id: String,        // Slack user ID; one active deduction operation per user
+  operationId: String,
+  kind: "ephemeral" | "stadium-in-flight",
+  ownerId: String,
+  createdAt: Date,
+  expiresAt: Date
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,7 +126,7 @@ native Collection object used directly by services.
   // Stadium deductions additionally contain:
   source: "stadium",
   status: "reserved" | "sending" | "fulfilled" | "failed" | "needs_review" | "refunded",
-  corporateEmail: String,
+  corporateEmail: String, // normalized modal input or Slack profile email
   stadiumPoints: Number,
   ratio: { fistbumpsPerUnit: Number, pointsPerUnit: Number },
   updatedAt: Date,

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -117,6 +117,49 @@ DMing the bot with `balance` or `help`.
 | `REDEMPTION_ADMINS` | (hardcoded list) | Comma-separated Slack user IDs who can manage redemptions |
 | `GOLDEN_RECOGNIZE_HOLDER` | `UE1QRFSSY` | Slack user ID of initial golden fistbump holder |
 | `PORT` | `3000` | HTTP port for the health check Express server |
+| `STADIUM_ENABLED` | `false` | Toggles Stadium redemption category visibility |
+| `STADIUM_API_BASE_URL` | — | Stadium API v2 base URL |
+| `STADIUM_CLIENT_ID` | — | OAuth client ID |
+| `STADIUM_CLIENT_SECRET` | — | OAuth client secret |
+| `STADIUM_STORE_NUMBER` | — | Global organization store number |
+| `STADIUM_STORE_URL` | — | SSO store URL shown after successful redemption |
+| `STADIUM_PAYMENT_METHOD` | — | `use_wallet_money`, `use_global_point`, or both comma-separated |
+| `STADIUM_BILLING_COUNTRY` | — | Billing country sent to Stadium |
+| `STADIUM_BILLING_ZIPCODE` | — | Billing postal code sent to Stadium |
+| `STADIUM_FISTBUMPS_PER_UNIT` | `1` | Fistbumps in one conversion unit |
+| `STADIUM_POINTS_PER_UNIT` | `1` | Stadium points issued per unit |
+| `STADIUM_MIN_FISTBUMPS` | `1` | Minimum redemption amount |
+| `STADIUM_MAX_FISTBUMPS` | current balance | Optional positive whole-number maximum |
+
+### Stadium sandbox verification
+
+Before enabling Stadium in an environment, reinstall the Slack app with the `users:read.email`
+scope and configure all non-secret Stadium settings above. The App Service reads
+`stadium-client-id` and `stadium-client-secret` directly from Azure Key Vault using versionless
+Key Vault references; Terraform does not read those values into state.
+
+For a manual sandbox test:
+
+1. Configure the nonprod store number, payment method, billing values, SSO URL, and desired
+   conversion ratio. Set `stadium_enabled: true` only in nonprod and apply its Terraform plan.
+2. DM Gratibot `redeem`, choose **Redeem with Stadium**, and submit a small whole-number
+   fistbump amount using a Slack user whose profile email ends exactly in `@liatrio.com`.
+3. Confirm the deduction is present, the Stadium response is paid, the points appear in the
+   same employee account reached through SSO, and no invitation flow is required. This also
+   confirms the assumed `auto_accept_points: true` behavior.
+4. Exercise a rejected request and verify the fistbumps are restored. Exercise an uncertain
+   response only in a controlled test: confirm `stadium review` lists it and resolve it with
+   `stadium resolve <id> fulfilled` or `stadium resolve <id> refund` after checking Stadium.
+5. Confirm the API response fields (`number` and `payment_state: paid`), fees/taxes, inventory
+   behavior, and refund policy with Stadium before enabling production.
+
+The application never retries `send_points`: a timeout, rate limit, server error, or malformed
+success response holds the fistbumps and requires admin review to avoid issuing points twice.
+Short-lived deduction locks use time-bounded ownership leases and can be atomically reclaimed after
+expiry. An unresolved Stadium deduction is the authoritative review hold, so it cannot leave a
+separate permanent lock behind. Periodic reconciliation restores interrupted local reservations,
+moves stale in-flight API requests to admin review, retries undelivered admin notifications with
+a leased backoff, and removes legacy review-lock records.
 
 ## Conventional Commits
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -118,11 +118,12 @@ DMing the bot with `balance` or `help`.
 | `GOLDEN_RECOGNIZE_HOLDER` | `UE1QRFSSY` | Slack user ID of initial golden fistbump holder |
 | `PORT` | `3000` | HTTP port for the health check Express server |
 | `STADIUM_ENABLED` | `false` | Toggles Stadium redemption category visibility |
+| `STADIUM_EMAIL_SOURCE` | `modal` | Recipient email source: required modal input or Slack profile lookup |
 | `STADIUM_API_BASE_URL` | — | Stadium API v2 base URL |
 | `STADIUM_CLIENT_ID` | — | OAuth client ID |
 | `STADIUM_CLIENT_SECRET` | — | OAuth client secret |
 | `STADIUM_STORE_NUMBER` | — | Global organization store number |
-| `STADIUM_STORE_URL` | — | SSO store URL shown after successful redemption |
+| `STADIUM_STORE_URL` | — | Stadium URL shown after successful order creation |
 | `STADIUM_PAYMENT_METHOD` | — | `use_wallet_money`, `use_global_point`, or both comma-separated |
 | `STADIUM_BILLING_COUNTRY` | — | Billing country sent to Stadium |
 | `STADIUM_BILLING_ZIPCODE` | — | Billing postal code sent to Stadium |
@@ -133,20 +134,24 @@ DMing the bot with `balance` or `help`.
 
 ### Stadium sandbox verification
 
-Before enabling Stadium in an environment, reinstall the Slack app with the `users:read.email`
-scope and configure all non-secret Stadium settings above. The App Service reads
+Before enabling Stadium in an environment, configure all non-secret Stadium settings above. The
+default `modal` email source asks the employee for their Liatrio address and does not require a
+Slack app reinstall. The `slack` source reads the address from the employee's profile and requires
+reinstalling the app with the `users:read.email` scope. The App Service reads
 `stadium-client-id` and `stadium-client-secret` directly from Azure Key Vault using versionless
 Key Vault references; Terraform does not read those values into state.
 
 For a manual sandbox test:
 
-1. Configure the nonprod store number, payment method, billing values, SSO URL, and desired
-   conversion ratio. Set `stadium_enabled: true` only in nonprod and apply its Terraform plan.
+1. Configure the nonprod store number, payment method, billing values, store URL, email source, and
+   desired conversion ratio. Set `stadium_enabled: true` only in nonprod and apply its Terraform
+   plan.
 2. DM Gratibot `redeem`, choose **Redeem with Stadium**, and submit a small whole-number
-   fistbump amount using a Slack user whose profile email ends exactly in `@liatrio.com`.
-3. Confirm the deduction is present, the Stadium response is paid, the points appear in the
-   same employee account reached through SSO, and no invitation flow is required. This also
-   confirms the assumed `auto_accept_points: true` behavior.
+   fistbump amount. In `modal` mode, enter the employee's exact `@liatrio.com` address; in `slack`
+   mode, use a Slack user whose profile email ends exactly in `@liatrio.com`.
+3. Confirm the deduction is present, the Stadium response is paid, and the gift appears for the
+   intended employee. Open Stadium and select **Redeem Gift** to add the points to the account;
+   `auto_accept_points: true` does not guarantee that this recipient action is skipped.
 4. Exercise a rejected request and verify the fistbumps are restored. Exercise an uncertain
    response only in a controlled test: confirm `stadium review` lists it and resolve it with
    `stadium resolve <id> fulfilled` or `stadium resolve <id> refund` after checking Stadium.

--- a/features/deduction.js
+++ b/features/deduction.js
@@ -58,22 +58,38 @@ async function respondToDeduction({ message, client }) {
   const user = messageText[2].match(userRegex)[1];
   const value = +messageText[3];
 
-  if (!(await deduction.isBalanceSufficient(user, value))) {
+  const operationId = `admin-deduction:${message.ts || Date.now()}`;
+  const lockResult = await deduction.acquireLock(user, operationId);
+  if (!lockResult.acquired) {
+    const text =
+      lockResult.reason === "stadium-review"
+        ? `<@${user}> has a Stadium redemption awaiting review (${lockResult.operationId}). Run \`stadium review\` to resolve it before creating another deduction.`
+        : `<@${user}> already has a deduction or redemption in progress.`;
     await respondToUser(client, message, {
-      text: `<@${user}> does not have a large enough balance to deduct ${value} fistbumps.`,
+      text,
     });
     return;
   }
+  try {
+    if (!(await deduction.isBalanceSufficient(user, value))) {
+      await respondToUser(client, message, {
+        text: `<@${user}> does not have a large enough balance to deduct ${value} fistbumps.`,
+      });
+      return;
+    }
 
-  const deductionInfo = await deduction.createDeduction(
-    user,
-    value,
-    message.text,
-  );
+    const deductionInfo = await deduction.createDeduction(
+      user,
+      value,
+      message.text,
+    );
 
-  await client.chat.postMessage({
-    channel: message.channel,
-    user: message.user,
-    text: `A deduction of ${value} fistbumps has been made for <@${user}>. Deduction ID is \`${deductionInfo._id}\``,
-  });
+    await client.chat.postMessage({
+      channel: message.channel,
+      user: message.user,
+      text: `A deduction of ${value} fistbumps has been made for <@${user}>. Deduction ID is \`${deductionInfo}\``,
+    });
+  } finally {
+    await deduction.releaseLock(user, operationId);
+  }
 }

--- a/features/redeem.js
+++ b/features/redeem.js
@@ -42,36 +42,67 @@ async function redeemItem({ ack, body, context, client }) {
 
     const { name, cost, kind } = reward;
 
-    if (!(await deduction.isBalanceSufficient(userID, cost))) {
-      return client.chat.postEphemeral({
-        channel: body.channel.id,
-        user: userID,
-        text: "Your current balance isn't high enough to deduct that much",
-      });
-    }
-
-    const result = await client.conversations.open({
-      token: context.botToken,
-      users: redeem.redeemNotificationUsers(userID),
-    });
-
     let redemptionMessage = `<@${userID}> has selected ${name}`;
     if (kind === "liatrio-store") {
+      if (!(await deduction.isBalanceSufficient(userID, cost))) {
+        return client.chat.postEphemeral({
+          channel: body.channel.id,
+          user: userID,
+          text: "Your current balance isn't high enough to deduct that much",
+        });
+      }
+      const result = await client.conversations.open({
+        token: context.botToken,
+        users: redeem.redeemNotificationUsers(userID),
+      });
       redemptionMessage += `. Please provide the link of the item from the <https://liatrio.axomo.com/|Liatrio Store>.`;
+      await client.chat.postMessage({
+        channel: result.channel.id,
+        token: context.botToken,
+        text: redemptionMessage,
+      });
     } else {
-      redemptionMessage += ` for ${cost} fistbumps.`;
-      const deductionID = await deduction.createDeduction(
-        userID,
-        cost,
-        redemptionMessage,
-      );
-      redemptionMessage += ` Deduction ID is \`${deductionID}\``;
+      const operationId = `reward:${body.actions[0].action_ts || rewardId}`;
+      const lockResult = await deduction.acquireLock(userID, operationId);
+      if (!lockResult.acquired) {
+        const text =
+          lockResult.reason === "stadium-review"
+            ? "A Stadium redemption is awaiting admin review. You can redeem another reward after it is resolved."
+            : "You already have a redemption in progress. Please try again shortly.";
+        return client.chat.postEphemeral({
+          channel: body.channel.id,
+          user: userID,
+          text,
+        });
+      }
+      try {
+        if (!(await deduction.isBalanceSufficient(userID, cost))) {
+          return client.chat.postEphemeral({
+            channel: body.channel.id,
+            user: userID,
+            text: "Your current balance isn't high enough to deduct that much",
+          });
+        }
+        const result = await client.conversations.open({
+          token: context.botToken,
+          users: redeem.redeemNotificationUsers(userID),
+        });
+        redemptionMessage += ` for ${cost} fistbumps.`;
+        const deductionID = await deduction.createDeduction(
+          userID,
+          cost,
+          redemptionMessage,
+        );
+        redemptionMessage += ` Deduction ID is \`${deductionID}\``;
+        await client.chat.postMessage({
+          channel: result.channel.id,
+          token: context.botToken,
+          text: redemptionMessage,
+        });
+      } finally {
+        await deduction.releaseLock(userID, operationId);
+      }
     }
-    await client.chat.postMessage({
-      channel: result.channel.id,
-      token: context.botToken,
-      text: redemptionMessage,
-    });
   } catch (error) {
     winston.error("redeemItem failed", {
       func: "feature.redeem.redeemItem",

--- a/features/refund.js
+++ b/features/refund.js
@@ -4,7 +4,7 @@ const refund = require("../service/refund");
 
 module.exports = function (app) {
   app.message(
-    /refund/i,
+    /^(?!.*\bstadium\s+resolve\b.*\brefund\b).*\brefund\b/is,
     anyOf(directMention, directMessage),
     refund.respondToRefund,
   );

--- a/features/stadium-redeem.js
+++ b/features/stadium-redeem.js
@@ -1,0 +1,282 @@
+const { directMention } = require("@slack/bolt");
+const { anyOf, directMessage } = require("../middleware");
+const config = require("../config");
+const winston = require("../winston");
+const stadium = require("../service/stadium");
+const { respondToUser } = require("../service/messageutils");
+
+module.exports = function (app) {
+  app.action({ action_id: "stadium_redeem_open" }, openRedemptionModal);
+  app.view("stadium_redeem_submit", submitRedemption);
+  app.message(
+    /\bstadium review\b/i,
+    anyOf(directMention, directMessage),
+    reviewRedemptions,
+  );
+  app.message(
+    /^(?!.*\brefund\b.*\bstadium\s+resolve\b).*\bstadium\s+resolve\b/is,
+    anyOf(directMention, directMessage),
+    resolveRedemption,
+  );
+};
+
+async function openRedemptionModal({ ack, body, client }) {
+  await ack();
+  if (!config.stadium.enabled) {
+    await notifyUser(
+      client,
+      body.user.id,
+      "Stadium redemption is currently unavailable.",
+    );
+    return;
+  }
+  try {
+    await client.views.open({
+      trigger_id: body.trigger_id,
+      view: stadium.buildRedemptionModal(),
+    });
+  } catch (error) {
+    winston.error("Opening Stadium redemption modal failed", {
+      func: "feature.stadium-redeem.openRedemptionModal",
+      callingUser: body.user.id,
+      error: error.message,
+    });
+    await notifyUser(
+      client,
+      body.user.id,
+      "I couldn't open the Stadium redemption form. Please try again or contact an admin.",
+    );
+  }
+}
+
+async function submitRedemption({ ack, body, view, client }) {
+  if (!config.stadium.enabled) {
+    await ack();
+    await notifyUser(
+      client,
+      body.user.id,
+      "Stadium redemption is currently unavailable.",
+    );
+    return;
+  }
+  const amount = Number(
+    view.state.values.stadium_amount.stadium_amount_value.value,
+  );
+  try {
+    stadium.fistbumpsToPoints(amount);
+  } catch (error) {
+    await ack({
+      response_action: "errors",
+      errors: { stadium_amount: error.userMessage || error.message },
+    });
+    return;
+  }
+  await ack();
+  const user = body.user.id;
+  let userInfo;
+  try {
+    userInfo = await client.users.info({ user });
+  } catch (error) {
+    winston.error("Reading Slack email for Stadium redemption failed", {
+      func: "feature.stadium-redeem.submitRedemption.usersInfo",
+      callingUser: user,
+      error: error.message,
+    });
+    await notifyUser(
+      client,
+      user,
+      "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
+    );
+    return;
+  }
+  if (!userInfo.ok || !userInfo.user?.profile?.email) {
+    await notifyUser(
+      client,
+      user,
+      "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
+    );
+    return;
+  }
+  let result;
+  try {
+    result = await stadium.redeem({
+      user,
+      email: userInfo.user.profile.email,
+      fistbumps: amount,
+      redemptionId: `${body.team?.id || "team"}:${view.id}`,
+    });
+  } catch (error) {
+    winston.error("Stadium redemption processing failed", {
+      func: "feature.stadium-redeem.submitRedemption",
+      callingUser: user,
+      error: error.message,
+    });
+    const message =
+      error instanceof stadium.StadiumError && error.userMessage
+        ? error.userMessage
+        : "I couldn't confirm the final status of your Stadium redemption. Please contact a Gratibot admin before trying again.";
+    await notifyUser(client, user, message);
+    return;
+  }
+  try {
+    await handleResult(client, user, amount, result);
+  } catch (error) {
+    winston.error("Reporting Stadium redemption result failed", {
+      func: "feature.stadium-redeem.submitRedemption",
+      callingUser: user,
+      redemptionId: result.id,
+      status: result.status,
+      error: error.message,
+    });
+    try {
+      await notifyUser(
+        client,
+        user,
+        "Your Stadium redemption was processed, but I couldn't deliver its confirmation. Please contact a Gratibot admin before trying again.",
+      );
+    } catch {
+      // best-effort fallback after the original notification failed
+    }
+  }
+}
+
+async function handleResult(client, user, amount, result) {
+  const messages = {
+    insufficient:
+      "Your current balance is no longer high enough for that redemption.",
+    duplicate:
+      "This redemption was already submitted; no additional points were sent.",
+    failed:
+      "Stadium did not accept the redemption. Your fistbumps were restored.",
+    needs_review:
+      "Stadium's result was uncertain. Your fistbumps are held while an admin reviews it; Gratibot will not retry automatically.",
+    resolution_conflict:
+      "Stadium confirmed the points after this redemption had already been resolved locally. Do not retry; a Gratibot admin has been notified.",
+  };
+  if (result.status === "fulfilled") {
+    const link = config.stadium.storeUrl
+      ? ` Sign in with SSO at <${config.stadium.storeUrl}|Stadium>.`
+      : " Sign in to Stadium with SSO to use them.";
+    await notifyUser(
+      client,
+      user,
+      `${amount} fistbumps were exchanged for ${result.stadiumPoints} Stadium points.${link}${result.orderNumber ? ` Order: \`${result.orderNumber}\`` : ""}`,
+    );
+    return;
+  }
+  const message =
+    result.status === "busy" && result.reason === "stadium-review"
+      ? "A Stadium redemption is awaiting admin review. You can redeem again after an admin resolves it."
+      : result.status === "busy"
+        ? "You already have a redemption in progress. Please try again shortly."
+        : messages[result.status];
+  await notifyUser(client, user, message);
+  if (result.status === "needs_review") {
+    await notifyReviewAdmins(client, user, result.id);
+  }
+  if (result.status === "resolution_conflict") {
+    await notifyAdmins(
+      client,
+      `Stadium redemption \`${result.id}\` for <@${user}> was confirmed as order \`${result.orderNumber}\` after its local status became ${result.terminalStatus}. Investigate before the employee redeems again.`,
+    );
+  }
+}
+
+async function reviewRedemptions({ message, client }) {
+  if (!config.redemptionAdmins.includes(message.user)) {
+    await respondToUser(client, message, {
+      text: "Only `Redemption Admins` can review Stadium redemptions.",
+    });
+    return;
+  }
+  const records = await stadium.reviewRedemptions();
+  const text = records.length
+    ? records
+        .map(
+          (record) =>
+            `\`${record._id}\` — <@${record.user}>, ${record.value} fistbumps${record.stadium?.orderNumber ? `, Stadium order ${record.stadium.orderNumber}` : ""}`,
+        )
+        .join("\n")
+    : "No Stadium redemptions need review.";
+  await respondToUser(client, message, { text });
+}
+
+async function resolveRedemption({ message, client }) {
+  if (!config.redemptionAdmins.includes(message.user)) {
+    await respondToUser(client, message, {
+      text: "Only `Redemption Admins` can resolve Stadium redemptions.",
+    });
+    return;
+  }
+  const match = message.text.match(
+    /\bstadium resolve\s+`?(stadium:[^\s`]+)`?\s+(fulfilled|refund)\s*$/i,
+  );
+  if (!match) {
+    await respondToUser(client, message, {
+      text: "Usage: `stadium resolve <id> fulfilled` or `stadium resolve <id> refund`",
+    });
+    return;
+  }
+  const result = await stadium.resolveRedemption(
+    match[1],
+    match[2].toLowerCase(),
+    message.user,
+  );
+  const text =
+    result.status === "not_found"
+      ? "That unresolved Stadium redemption was not found."
+      : `Stadium redemption \`${match[1]}\` was marked ${result.status}.`;
+  await respondToUser(client, message, { text });
+  if (result.record) {
+    await notifyUser(
+      client,
+      result.record.user,
+      result.status === "refunded"
+        ? `Your Stadium redemption \`${match[1]}\` was reviewed and your fistbumps were restored.`
+        : `Your Stadium redemption \`${match[1]}\` was reviewed and confirmed fulfilled.`,
+    );
+  }
+}
+
+async function notifyUser(client, user, text) {
+  return client.chat.postMessage({ channel: user, text });
+}
+
+async function notifyReviewAdmins(client, user, redemptionId) {
+  let claim;
+  try {
+    claim = await stadium.claimReviewNotification(redemptionId);
+    if (!claim) return;
+    const delivered = await notifyAdmins(
+      client,
+      `Stadium redemption \`${redemptionId}\` for <@${user}> needs review. Run \`stadium review\`, then either \`stadium resolve ${redemptionId} fulfilled\` to confirm fulfillment or \`stadium resolve ${redemptionId} refund\` to restore the fistbumps.`,
+    );
+    await stadium.completeReviewNotification(
+      redemptionId,
+      claim.claimId,
+      delivered,
+    );
+  } catch (error) {
+    winston.error("Scheduling Stadium admin notification failed", {
+      func: "feature.stadium-redeem.notifyReviewAdmins",
+      redemptionId,
+      error: error.message,
+    });
+  }
+}
+
+async function notifyAdmins(client, text) {
+  const results = await Promise.allSettled(
+    config.redemptionAdmins.map((admin) =>
+      client.chat.postMessage({ channel: admin, text }),
+    ),
+  );
+  const failed = results.filter((result) => result.status === "rejected");
+  if (failed.length) {
+    winston.error("Some Stadium admin notifications failed", {
+      func: "feature.stadium-redeem.notifyAdmins",
+      failedCount: failed.length,
+    });
+  }
+  return results.some((result) => result.status === "fulfilled");
+}

--- a/features/stadium-redeem.js
+++ b/features/stadium-redeem.js
@@ -41,12 +41,23 @@ async function openRedemptionModal({ ack, body, client }) {
       callingUser: body.user.id,
       error: error.message,
     });
-    await notifyUser(
-      client,
-      body.user.id,
-      "I couldn't open the Stadium redemption form. Please try again or contact an admin.",
-    );
+    const message =
+      error instanceof stadium.StadiumError && error.userMessage
+        ? error.userMessage
+        : "I couldn't open the Stadium redemption form. Please try again or contact an admin.";
+    await notifyUser(client, body.user.id, message);
   }
+}
+
+function emailSourceFromView(view) {
+  if (view.private_metadata) {
+    const metadata = JSON.parse(view.private_metadata);
+    if (!metadata || typeof metadata.emailSource !== "string") {
+      throw new Error("Missing Stadium email source metadata");
+    }
+    return stadium.validateEmailSource(metadata.emailSource);
+  }
+  return view.state.values.stadium_email ? "modal" : "slack";
 }
 
 async function submitRedemption({ ack, body, view, client }) {
@@ -59,49 +70,107 @@ async function submitRedemption({ ack, body, view, client }) {
     );
     return;
   }
+  let currentEmailSource;
+  try {
+    currentEmailSource = stadium.validateEmailSource();
+  } catch (error) {
+    await ack();
+    await notifyUser(
+      client,
+      body.user.id,
+      error.userMessage || "Stadium redemption is currently unavailable.",
+    );
+    return;
+  }
+  let emailSource;
+  try {
+    emailSource = emailSourceFromView(view);
+  } catch {
+    await ack();
+    await notifyUser(
+      client,
+      body.user.id,
+      "This Stadium redemption form is no longer valid. Please reopen it and try again.",
+    );
+    return;
+  }
+  if (emailSource !== currentEmailSource) {
+    await ack();
+    await notifyUser(
+      client,
+      body.user.id,
+      "Stadium redemption settings changed while this form was open. Please reopen it and try again.",
+    );
+    return;
+  }
+  const errors = {};
   const amount = Number(
     view.state.values.stadium_amount.stadium_amount_value.value,
   );
   try {
     stadium.fistbumpsToPoints(amount);
   } catch (error) {
-    await ack({
-      response_action: "errors",
-      errors: { stadium_amount: error.userMessage || error.message },
-    });
+    errors.stadium_amount = error.userMessage || error.message;
+  }
+  let corporateEmail;
+  if (emailSource === "modal") {
+    try {
+      corporateEmail = stadium.normalizeCorporateEmail(
+        view.state.values.stadium_email?.stadium_email_value?.value,
+      );
+    } catch (error) {
+      errors.stadium_email = error.userMessage || error.message;
+    }
+  }
+  if (Object.keys(errors).length) {
+    await ack({ response_action: "errors", errors });
     return;
   }
   await ack();
   const user = body.user.id;
-  let userInfo;
-  try {
-    userInfo = await client.users.info({ user });
-  } catch (error) {
-    winston.error("Reading Slack email for Stadium redemption failed", {
-      func: "feature.stadium-redeem.submitRedemption.usersInfo",
-      callingUser: user,
-      error: error.message,
-    });
-    await notifyUser(
-      client,
-      user,
-      "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
-    );
-    return;
-  }
-  if (!userInfo.ok || !userInfo.user?.profile?.email) {
-    await notifyUser(
-      client,
-      user,
-      "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
-    );
-    return;
+  if (emailSource === "slack") {
+    let userInfo;
+    try {
+      userInfo = await client.users.info({ user });
+    } catch (error) {
+      winston.error("Reading Slack email for Stadium redemption failed", {
+        func: "feature.stadium-redeem.submitRedemption.usersInfo",
+        callingUser: user,
+        error: error.message,
+      });
+      await notifyUser(
+        client,
+        user,
+        "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
+      );
+      return;
+    }
+    if (!userInfo.ok || !userInfo.user?.profile?.email) {
+      await notifyUser(
+        client,
+        user,
+        "I couldn't read your corporate email from Slack. Check your profile or contact a Gratibot admin.",
+      );
+      return;
+    }
+    try {
+      corporateEmail = stadium.normalizeCorporateEmail(
+        userInfo.user.profile.email,
+      );
+    } catch {
+      await notifyUser(
+        client,
+        user,
+        "Your Slack profile must contain a valid @liatrio.com email address. Update your profile or contact a Gratibot admin.",
+      );
+      return;
+    }
   }
   let result;
   try {
     result = await stadium.redeem({
       user,
-      email: userInfo.user.profile.email,
+      email: corporateEmail,
       fistbumps: amount,
       redemptionId: `${body.team?.id || "team"}:${view.id}`,
     });
@@ -119,7 +188,7 @@ async function submitRedemption({ ack, body, view, client }) {
     return;
   }
   try {
-    await handleResult(client, user, amount, result);
+    await handleResult(client, user, amount, corporateEmail, result);
   } catch (error) {
     winston.error("Reporting Stadium redemption result failed", {
       func: "feature.stadium-redeem.submitRedemption",
@@ -140,7 +209,7 @@ async function submitRedemption({ ack, body, view, client }) {
   }
 }
 
-async function handleResult(client, user, amount, result) {
+async function handleResult(client, user, amount, corporateEmail, result) {
   const messages = {
     insufficient:
       "Your current balance is no longer high enough for that redemption.",
@@ -151,16 +220,16 @@ async function handleResult(client, user, amount, result) {
     needs_review:
       "Stadium's result was uncertain. Your fistbumps are held while an admin reviews it; Gratibot will not retry automatically.",
     resolution_conflict:
-      "Stadium confirmed the points after this redemption had already been resolved locally. Do not retry; a Gratibot admin has been notified.",
+      "Stadium confirmed the paid order after this redemption had already been resolved locally. Do not retry; a Gratibot admin has been notified.",
   };
   if (result.status === "fulfilled") {
     const link = config.stadium.storeUrl
-      ? ` Sign in with SSO at <${config.stadium.storeUrl}|Stadium>.`
-      : " Sign in to Stadium with SSO to use them.";
+      ? `<${config.stadium.storeUrl}|Open Stadium>`
+      : "Open Stadium";
     await notifyUser(
       client,
       user,
-      `${amount} fistbumps were exchanged for ${result.stadiumPoints} Stadium points.${link}${result.orderNumber ? ` Order: \`${result.orderNumber}\`` : ""}`,
+      `${amount} fistbumps were exchanged for ${result.stadiumPoints} Stadium points and sent to ${corporateEmail}. Your Stadium gift is ready to redeem. ${link} and select *Redeem Gift*.${result.orderNumber ? ` Order: \`${result.orderNumber}\`` : ""}`,
     );
     return;
   }

--- a/infra/terraform/appservice.tf
+++ b/infra/terraform/appservice.tf
@@ -49,5 +49,18 @@ resource "azurerm_linux_web_app" "gratibot_app_service" {
     "REACTION_EMOJI"              = var.gratibot_reaction_emoji
     "LOG_LEVEL"                   = var.gratibot_log_level
     "GRATIBOT_LIMIT"              = var.gratibot_limit
+    "STADIUM_ENABLED"             = tostring(var.stadium_enabled)
+    "STADIUM_API_BASE_URL"        = var.stadium_api_base_url
+    "STADIUM_CLIENT_ID"           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault.gratibot.vault_uri}secrets/stadium-client-id)"
+    "STADIUM_CLIENT_SECRET"       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault.gratibot.vault_uri}secrets/stadium-client-secret)"
+    "STADIUM_STORE_NUMBER"        = var.stadium_store_number
+    "STADIUM_STORE_URL"           = var.stadium_store_url
+    "STADIUM_PAYMENT_METHOD"      = var.stadium_payment_method
+    "STADIUM_BILLING_COUNTRY"     = var.stadium_billing_country
+    "STADIUM_BILLING_ZIPCODE"     = var.stadium_billing_zipcode
+    "STADIUM_FISTBUMPS_PER_UNIT"  = tostring(var.stadium_fistbumps_per_unit)
+    "STADIUM_POINTS_PER_UNIT"     = tostring(var.stadium_points_per_unit)
+    "STADIUM_MIN_FISTBUMPS"       = tostring(var.stadium_min_fistbumps)
+    "STADIUM_MAX_FISTBUMPS"       = var.stadium_max_fistbumps
   }
 }

--- a/infra/terraform/appservice.tf
+++ b/infra/terraform/appservice.tf
@@ -50,6 +50,7 @@ resource "azurerm_linux_web_app" "gratibot_app_service" {
     "LOG_LEVEL"                   = var.gratibot_log_level
     "GRATIBOT_LIMIT"              = var.gratibot_limit
     "STADIUM_ENABLED"             = tostring(var.stadium_enabled)
+    "STADIUM_EMAIL_SOURCE"        = var.stadium_email_source
     "STADIUM_API_BASE_URL"        = var.stadium_api_base_url
     "STADIUM_CLIENT_ID"           = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault.gratibot.vault_uri}secrets/stadium-client-id)"
     "STADIUM_CLIENT_SECRET"       = "@Microsoft.KeyVault(SecretUri=${data.azurerm_key_vault.gratibot.vault_uri}secrets/stadium-client-secret)"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -86,6 +86,17 @@ variable "stadium_enabled" {
   default     = false
 }
 
+variable "stadium_email_source" {
+  description = "Source for the Stadium recipient email: modal input or Slack profile"
+  type        = string
+  default     = "modal"
+
+  validation {
+    condition     = contains(["modal", "slack"], var.stadium_email_source)
+    error_message = "stadium_email_source must be modal or slack."
+  }
+}
+
 variable "stadium_api_base_url" {
   description = "Stadium API v2 base URL"
   type        = string
@@ -99,7 +110,7 @@ variable "stadium_store_number" {
 }
 
 variable "stadium_store_url" {
-  description = "Stadium SSO store URL shown after fulfillment"
+  description = "Stadium URL shown after successful order creation"
   type        = string
   default     = ""
 }

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -79,3 +79,78 @@ variable "gratibot_limit" {
   type        = string
   default     = "5"
 }
+
+variable "stadium_enabled" {
+  description = "Whether Stadium redemption is exposed to users"
+  type        = bool
+  default     = false
+}
+
+variable "stadium_api_base_url" {
+  description = "Stadium API v2 base URL"
+  type        = string
+  default     = "https://api.preprod.bystadium.com/api/v2"
+}
+
+variable "stadium_store_number" {
+  description = "Global organization Stadium store number"
+  type        = string
+  default     = ""
+}
+
+variable "stadium_store_url" {
+  description = "Stadium SSO store URL shown after fulfillment"
+  type        = string
+  default     = ""
+}
+
+variable "stadium_payment_method" {
+  description = "Comma-separated Stadium send_points methods: use_wallet_money and/or use_global_point"
+  type        = string
+  default     = ""
+}
+
+variable "stadium_billing_country" {
+  description = "Stadium billing country"
+  type        = string
+  default     = ""
+}
+
+variable "stadium_billing_zipcode" {
+  description = "Stadium billing postal code"
+  type        = string
+  default     = ""
+}
+
+variable "stadium_fistbumps_per_unit" {
+  description = "Fistbumps in one conversion unit"
+  type        = number
+  default     = 1
+}
+
+variable "stadium_points_per_unit" {
+  description = "Stadium points issued per conversion unit"
+  type        = number
+  default     = 1
+}
+
+variable "stadium_min_fistbumps" {
+  description = "Minimum fistbumps per Stadium redemption"
+  type        = number
+  default     = 1
+}
+
+variable "stadium_max_fistbumps" {
+  description = "Optional maximum fistbumps per Stadium redemption"
+  type        = string
+  default     = ""
+
+  validation {
+    condition = var.stadium_max_fistbumps == "" || (
+      can(tonumber(var.stadium_max_fistbumps)) &&
+      tonumber(var.stadium_max_fistbumps) >= 1 &&
+      floor(tonumber(var.stadium_max_fistbumps)) == tonumber(var.stadium_max_fistbumps)
+    )
+    error_message = "stadium_max_fistbumps must be empty or a positive whole number."
+  }
+}

--- a/infra/terragrunt/nonprod/environment.yaml
+++ b/infra/terragrunt/nonprod/environment.yaml
@@ -3,6 +3,7 @@ gratibot_self_recognize_emoji: ":nonprod-self-fistbump:"
 gratibot_log_level: "debug"
 # Enabled after reinstalling the Slack app and completing the nonprod checks.
 stadium_enabled: true
+stadium_email_source: "modal"
 stadium_api_base_url: "https://api.preprod.bystadium.com/api/v2"
 stadium_store_number: "S508013635"
 stadium_store_url: "https://app.preprod.bystadium.com/"

--- a/infra/terragrunt/nonprod/environment.yaml
+++ b/infra/terragrunt/nonprod/environment.yaml
@@ -3,7 +3,7 @@ gratibot_self_recognize_emoji: ":nonprod-self-fistbump:"
 gratibot_log_level: "debug"
 # Enabled after reinstalling the Slack app and completing the nonprod checks.
 stadium_enabled: true
-stadium_email_source: "modal"
+stadium_email_source: "slack"
 stadium_api_base_url: "https://api.preprod.bystadium.com/api/v2"
 stadium_store_number: "S508013635"
 stadium_store_url: "https://app.preprod.bystadium.com/"

--- a/infra/terragrunt/nonprod/environment.yaml
+++ b/infra/terragrunt/nonprod/environment.yaml
@@ -1,6 +1,18 @@
 gratibot_recognize_emoji: ":oof:"
 gratibot_self_recognize_emoji: ":nonprod-self-fistbump:"
 gratibot_log_level: "debug"
+# Enabled after reinstalling the Slack app and completing the nonprod checks.
+stadium_enabled: true
+stadium_api_base_url: "https://api.preprod.bystadium.com/api/v2"
+stadium_store_number: "S508013635"
+stadium_store_url: "https://app.preprod.bystadium.com/"
+stadium_payment_method: "use_global_point"
+stadium_billing_country: "US"
+stadium_billing_zipcode: "95928"
+stadium_fistbumps_per_unit: 1
+stadium_points_per_unit: 1
+stadium_min_fistbumps: 1
+stadium_max_fistbumps: "" # Empty means the employee's current balance is the maximum.
 environment: "nonprod"
 state_storage_account: "gratibotazuredatatfnp"
 key_vault_name: "gratibot-np"

--- a/infra/terragrunt/prod/environment.yaml
+++ b/infra/terragrunt/prod/environment.yaml
@@ -5,9 +5,10 @@ environment: "prod"
 instance_capacity: "2"
 key_vault_name: "gratibot-p"
 stadium_enabled: false
+stadium_email_source: "modal"
 stadium_api_base_url: "https://api.bystadium.com/api/v2"
 stadium_store_number: "" # TODO: Set the production global organization store number.
-stadium_store_url: "" # TODO: Set the production Stadium SSO store URL.
+stadium_store_url: "" # TODO: Set the production Stadium URL.
 stadium_payment_method: "" # TODO: Set use_wallet_money, use_global_point, or both comma-separated.
 stadium_billing_country: "" # TODO: Set the production billing country ISO code.
 stadium_billing_zipcode: "" # TODO: Set the production billing postal code.

--- a/infra/terragrunt/prod/environment.yaml
+++ b/infra/terragrunt/prod/environment.yaml
@@ -4,15 +4,15 @@ state_storage_account: "gratibotazuredatatfpd"
 environment: "prod"
 instance_capacity: "2"
 key_vault_name: "gratibot-p"
-stadium_enabled: false
-stadium_email_source: "modal"
+stadium_enabled: true
+stadium_email_source: "slack"
 stadium_api_base_url: "https://api.bystadium.com/api/v2"
-stadium_store_number: "" # TODO: Set the production global organization store number.
-stadium_store_url: "" # TODO: Set the production Stadium URL.
-stadium_payment_method: "" # TODO: Set use_wallet_money, use_global_point, or both comma-separated.
-stadium_billing_country: "" # TODO: Set the production billing country ISO code.
-stadium_billing_zipcode: "" # TODO: Set the production billing postal code.
-stadium_fistbumps_per_unit: 1
+stadium_store_number: "S689644909"
+stadium_store_url: "https://app.bystadium.com/"
+stadium_payment_method: "use_wallet_money"
+stadium_billing_country: "US"
+stadium_billing_zipcode: "95928"
+stadium_fistbumps_per_unit: 2
 stadium_points_per_unit: 1
-stadium_min_fistbumps: 1
+stadium_min_fistbumps: 2
 stadium_max_fistbumps: "" # Empty means the employee's current balance is the maximum.

--- a/infra/terragrunt/prod/environment.yaml
+++ b/infra/terragrunt/prod/environment.yaml
@@ -4,3 +4,14 @@ state_storage_account: "gratibotazuredatatfpd"
 environment: "prod"
 instance_capacity: "2"
 key_vault_name: "gratibot-p"
+stadium_enabled: false
+stadium_api_base_url: "https://api.bystadium.com/api/v2"
+stadium_store_number: "" # TODO: Set the production global organization store number.
+stadium_store_url: "" # TODO: Set the production Stadium SSO store URL.
+stadium_payment_method: "" # TODO: Set use_wallet_money, use_global_point, or both comma-separated.
+stadium_billing_country: "" # TODO: Set the production billing country ISO code.
+stadium_billing_zipcode: "" # TODO: Set the production billing postal code.
+stadium_fistbumps_per_unit: 1
+stadium_points_per_unit: 1
+stadium_min_fistbumps: 1
+stadium_max_fistbumps: "" # Empty means the employee's current balance is the maximum.

--- a/service/deduction.js
+++ b/service/deduction.js
@@ -2,7 +2,12 @@ const winston = require("../winston");
 const moment = require("moment-timezone");
 const balance = require("../service/balance");
 const deductionCollection = require("../database/deductionCollection");
+const deductionLockCollection = require("../database/deductionLockCollection");
 const { ObjectId } = require("mongodb");
+const { randomUUID } = require("crypto");
+
+const LOCK_LEASE_MS = 5 * 60 * 1000;
+const lockOwnerId = randomUUID();
 
 async function createDeduction(user, value, message = "") {
   let timestamp = new Date();
@@ -25,10 +30,95 @@ async function createDeduction(user, value, message = "") {
 }
 
 async function refundDeduction(id) {
-  return await deductionCollection.findOneAndUpdate(
-    { _id: new ObjectId(id) },
+  let databaseId = id;
+  if (!(typeof id === "string" && id.startsWith("stadium:"))) {
+    try {
+      databaseId = new ObjectId(id);
+    } catch {
+      return { status: "not_found" };
+    }
+  }
+  const refunded = await deductionCollection.findOneAndUpdate(
+    { _id: databaseId, source: { $ne: "stadium" }, refund: false },
     { $set: { refund: true } },
   );
+  if (refunded) return { status: "refunded" };
+
+  const existing = await deductionCollection.findOne({ _id: databaseId });
+  if (!existing) return { status: "not_found" };
+  if (existing.source === "stadium") return { status: "stadium" };
+  return { status: "already_refunded" };
+}
+
+function createLock(user, operationId, kind, now, leaseMs) {
+  return {
+    _id: user,
+    operationId,
+    kind,
+    ownerId: lockOwnerId,
+    createdAt: now,
+    expiresAt: new Date(now.getTime() + leaseMs),
+  };
+}
+
+async function acquireLock(
+  user,
+  operationId,
+  { kind = "ephemeral", leaseMs = LOCK_LEASE_MS } = {},
+) {
+  const stadiumReview = await deductionCollection.findOne({
+    user,
+    source: "stadium",
+    status: "needs_review",
+  });
+  if (stadiumReview) {
+    return {
+      acquired: false,
+      reason: "stadium-review",
+      operationId: stadiumReview._id,
+    };
+  }
+
+  const now = new Date();
+  const lock = createLock(user, operationId, kind, now, leaseMs);
+  try {
+    await deductionLockCollection.insertOne(lock);
+    return { acquired: true };
+  } catch (error) {
+    if (error.code !== 11000) throw error;
+    const replacement = { ...lock };
+    delete replacement._id;
+    const replaced = await deductionLockCollection.findOneAndUpdate(
+      { _id: user, expiresAt: { $lte: now } },
+      { $set: replacement },
+    );
+    if (replaced) return { acquired: true };
+
+    const existing = await deductionLockCollection.findOne({ _id: user });
+    return {
+      acquired: false,
+      reason:
+        existing?.kind === "stadium-review" ? "stadium-review" : "in-progress",
+      operationId: existing?.operationId,
+    };
+  }
+}
+
+async function releaseLock(user, operationId, { force = false } = {}) {
+  const filter = { _id: user, operationId };
+  if (!force) filter.ownerId = lockOwnerId;
+  return deductionLockCollection.deleteOne(filter);
+}
+
+async function cleanupExpiredLocks(now = new Date()) {
+  return deductionLockCollection.deleteMany({
+    kind: { $in: ["ephemeral", "stadium-in-flight"] },
+    expiresAt: { $lte: now },
+  });
+}
+
+async function cleanupLegacyReviewLocks() {
+  return deductionLockCollection.deleteMany({ kind: "stadium-review" });
 }
 
 async function getDeductions(user, timezone = null, days = null) {
@@ -61,4 +151,9 @@ module.exports = {
   refundDeduction,
   getDeductions,
   isBalanceSufficient,
+  acquireLock,
+  releaseLock,
+  cleanupExpiredLocks,
+  cleanupLegacyReviewLocks,
+  LOCK_LEASE_MS,
 };

--- a/service/redeem.js
+++ b/service/redeem.js
@@ -36,7 +36,7 @@ function stadiumRedemption() {
     type: "section",
     text: {
       type: "mrkdwn",
-      text: "*Stadium points*\nExchange a whole-number amount of fistbumps for points in your Stadium account.",
+      text: "*Stadium points*\nExchange fistbumps for points in your Stadium account.",
     },
     accessory: {
       type: "button",

--- a/service/redeem.js
+++ b/service/redeem.js
@@ -27,7 +27,24 @@ function buildRedeemBlocks(rewards, currentBalance) {
     redeemHelpText(currentBalance),
     ...redeemItems(rewards),
     redeemSelector(rewards),
+    ...(config.stadium.enabled ? [stadiumRedemption()] : []),
   ];
+}
+
+function stadiumRedemption() {
+  return {
+    type: "section",
+    text: {
+      type: "mrkdwn",
+      text: "*Stadium points*\nExchange a whole-number amount of fistbumps for points in your Stadium account.",
+    },
+    accessory: {
+      type: "button",
+      action_id: "stadium_redeem_open",
+      text: { type: "plain_text", text: "Redeem with Stadium" },
+      style: "primary",
+    },
+  };
 }
 
 function redeemHeader() {
@@ -138,4 +155,5 @@ module.exports = {
   redeemHelpText,
   redeemItems,
   redeemSelector,
+  stadiumRedemption,
 };

--- a/service/refund.js
+++ b/service/refund.js
@@ -10,14 +10,32 @@ async function respondToRefund({ message, client, admins = redemptionAdmins }) {
   });
 
   if (admins.includes(message.user)) {
-    const messageText = message.text.split(" ");
-    const deductionId = messageText[messageText.indexOf("refund") + 1];
-    await deduction.refundDeduction(deductionId);
+    const match = message.text.match(
+      /\brefund\s+`?((?:[a-f\d]{24})|(?:stadium:[^\s`]+))`?\s*$/i,
+    );
+    if (!match) {
+      await client.chat.postMessage({
+        channel: message.channel,
+        user: message.user,
+        text: "Usage: `refund <deduction-id>`",
+      });
+      return;
+    }
+    const deductionId = match[1];
+    const result = await deduction.refundDeduction(deductionId);
+
+    const messages = {
+      refunded: "Refund successfully given",
+      already_refunded: "That deduction has already been refunded",
+      not_found: "That deduction could not be found",
+      stadium:
+        "Stadium deductions must be resolved with `stadium resolve <id> refund`.",
+    };
 
     await client.chat.postMessage({
       channel: message.channel,
       user: message.user,
-      text: "Refund successfully given",
+      text: messages[result.status],
     });
   } else {
     await client.chat.postMessage({

--- a/service/stadium.js
+++ b/service/stadium.js
@@ -6,6 +6,7 @@ const deductionCollection = require("../database/deductionCollection");
 const { randomUUID } = require("crypto");
 
 const CORPORATE_DOMAIN = "liatrio.com";
+const EMAIL_SOURCES = ["modal", "slack"];
 const REQUEST_TIMEOUT_MS = 10000;
 const REVIEW_NOTIFICATION_CLAIM_MS = 5 * 60 * 1000;
 const REVIEW_NOTIFICATION_RETRY_MS = 15 * 60 * 1000;
@@ -48,7 +49,18 @@ function validateConfiguration(stadiumConfig = config.stadium) {
   ) {
     throw new StadiumError("Invalid Stadium payment method.", "definite");
   }
+  validateEmailSource(stadiumConfig.emailSource);
   validateConversionConfiguration(stadiumConfig);
+}
+
+function validateEmailSource(emailSource = config.stadium.emailSource) {
+  if (!EMAIL_SOURCES.includes(emailSource)) {
+    throw new StadiumError("Invalid Stadium email source.", "definite", {
+      userMessage:
+        "Stadium redemption is unavailable because its email settings are invalid. Please contact a Gratibot admin.",
+    });
+  }
+  return emailSource;
 }
 
 function validateConversionConfiguration(stadiumConfig = config.stadium) {
@@ -88,10 +100,10 @@ function normalizeCorporateEmail(email) {
   const parts = normalized.split("@");
   if (parts.length !== 2 || !parts[0] || parts[1] !== CORPORATE_DOMAIN) {
     throw new StadiumError(
-      `Redemption requires a ${CORPORATE_DOMAIN} Slack profile email.`,
+      `Redemption requires an @${CORPORATE_DOMAIN} email address.`,
       "definite",
       {
-        userMessage: `Stadium redemption requires a ${CORPORATE_DOMAIN} email in your Slack profile.`,
+        userMessage: `Enter a valid @${CORPORATE_DOMAIN} email address.`,
       },
     );
   }
@@ -127,6 +139,7 @@ function buildRedemptionModal(
   currentBalance = null,
   stadiumConfig = config.stadium,
 ) {
+  const emailSource = validateEmailSource(stadiumConfig.emailSource);
   validateConversionConfiguration(stadiumConfig);
   const hasCurrentBalance = Number.isSafeInteger(currentBalance);
   const configuredMaximum = stadiumConfig.maximumFistbumps;
@@ -141,6 +154,7 @@ function buildRedemptionModal(
   return {
     type: "modal",
     callback_id: "stadium_redeem_submit",
+    private_metadata: JSON.stringify({ emailSource }),
     title: { type: "plain_text", text: "Stadium redemption" },
     submit: { type: "plain_text", text: "Redeem" },
     close: { type: "plain_text", text: "Cancel" },
@@ -149,9 +163,33 @@ function buildRedemptionModal(
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `Exchange fistbumps for Stadium points, then use your Liatrio SSO account at Stadium.${balanceText}\n*Rate:* ${stadiumConfig.fistbumpsPerUnit} fistbump(s) = ${stadiumConfig.pointsPerUnit} Stadium point(s)`,
+          text: `Exchange fistbumps for Stadium points. After your gift is created, open Stadium and select *Redeem Gift* to add the points to your account.${balanceText}\n*Rate:* ${stadiumConfig.fistbumpsPerUnit} fistbump(s) = ${stadiumConfig.pointsPerUnit} Stadium point(s)`,
         },
       },
+      ...(emailSource === "modal"
+        ? [
+            {
+              type: "input",
+              block_id: "stadium_email",
+              label: {
+                type: "plain_text",
+                text: "Your Liatrio email address",
+              },
+              hint: {
+                type: "plain_text",
+                text: "Enter your own @liatrio.com email address.",
+              },
+              element: {
+                type: "email_text_input",
+                action_id: "stadium_email_value",
+                placeholder: {
+                  type: "plain_text",
+                  text: "name@liatrio.com",
+                },
+              },
+            },
+          ]
+        : []),
       {
         type: "input",
         block_id: "stadium_amount",
@@ -658,6 +696,7 @@ function resetTokenCache() {
 
 module.exports = {
   StadiumError,
+  validateEmailSource,
   normalizeCorporateEmail,
   fistbumpsToPoints,
   buildRedemptionModal,

--- a/service/stadium.js
+++ b/service/stadium.js
@@ -1,0 +1,674 @@
+const config = require("../config");
+const winston = require("../winston");
+const deduction = require("./deduction");
+const balance = require("./balance");
+const deductionCollection = require("../database/deductionCollection");
+const { randomUUID } = require("crypto");
+
+const CORPORATE_DOMAIN = "liatrio.com";
+const REQUEST_TIMEOUT_MS = 10000;
+const REVIEW_NOTIFICATION_CLAIM_MS = 5 * 60 * 1000;
+const REVIEW_NOTIFICATION_RETRY_MS = 15 * 60 * 1000;
+let tokenCache = null;
+
+class StadiumError extends Error {
+  constructor(message, classification, details = {}) {
+    super(message);
+    this.name = "StadiumError";
+    this.classification = classification;
+    this.details = details;
+    this.userMessage = details.userMessage;
+  }
+}
+
+function validateConfiguration(stadiumConfig = config.stadium) {
+  const required = [
+    "apiBaseUrl",
+    "clientId",
+    "clientSecret",
+    "storeNumber",
+    "paymentMethod",
+    "billingCountry",
+    "billingZipcode",
+  ];
+  const missing = required.filter((key) => !stadiumConfig[key]);
+  if (missing.length) {
+    throw new StadiumError(
+      `Missing Stadium configuration: ${missing.join(", ")}`,
+      "definite",
+    );
+  }
+  const paymentMethods = stadiumConfig.paymentMethod
+    .split(",")
+    .map((method) => method.trim());
+  if (
+    paymentMethods.some(
+      (method) => !["use_wallet_money", "use_global_point"].includes(method),
+    )
+  ) {
+    throw new StadiumError("Invalid Stadium payment method.", "definite");
+  }
+  validateConversionConfiguration(stadiumConfig);
+}
+
+function validateConversionConfiguration(stadiumConfig = config.stadium) {
+  const {
+    fistbumpsPerUnit,
+    pointsPerUnit,
+    minimumFistbumps,
+    maximumFistbumps,
+  } = stadiumConfig;
+  const invalid =
+    !Number.isSafeInteger(fistbumpsPerUnit) ||
+    fistbumpsPerUnit < 1 ||
+    !Number.isSafeInteger(pointsPerUnit) ||
+    pointsPerUnit < 1 ||
+    !Number.isSafeInteger(minimumFistbumps) ||
+    minimumFistbumps < 1 ||
+    minimumFistbumps % fistbumpsPerUnit !== 0 ||
+    (maximumFistbumps !== null &&
+      (!Number.isSafeInteger(maximumFistbumps) ||
+        maximumFistbumps < minimumFistbumps));
+  if (invalid) {
+    throw new StadiumError(
+      "Invalid Stadium conversion configuration.",
+      "definite",
+      {
+        userMessage:
+          "Stadium redemption is unavailable because its conversion settings are invalid. Please contact a Gratibot admin.",
+      },
+    );
+  }
+}
+
+function normalizeCorporateEmail(email) {
+  const normalized = String(email || "")
+    .trim()
+    .toLowerCase();
+  const parts = normalized.split("@");
+  if (parts.length !== 2 || !parts[0] || parts[1] !== CORPORATE_DOMAIN) {
+    throw new StadiumError(
+      `Redemption requires a ${CORPORATE_DOMAIN} Slack profile email.`,
+      "definite",
+      {
+        userMessage: `Stadium redemption requires a ${CORPORATE_DOMAIN} email in your Slack profile.`,
+      },
+    );
+  }
+  return normalized;
+}
+
+function fistbumpsToPoints(amount, stadiumConfig = config.stadium) {
+  validateConversionConfiguration(stadiumConfig);
+  const fistbumps = Number(amount);
+  const {
+    fistbumpsPerUnit,
+    pointsPerUnit,
+    minimumFistbumps,
+    maximumFistbumps,
+  } = stadiumConfig;
+  if (
+    !Number.isSafeInteger(fistbumps) ||
+    fistbumps < minimumFistbumps ||
+    fistbumps % fistbumpsPerUnit !== 0 ||
+    (maximumFistbumps !== null && fistbumps > maximumFistbumps)
+  ) {
+    const multiple =
+      fistbumpsPerUnit > 1 ? ` in multiples of ${fistbumpsPerUnit}` : "";
+    throw new StadiumError(
+      `Enter a valid whole-number fistbump amount${multiple}.`,
+      "definite",
+    );
+  }
+  return (fistbumps / fistbumpsPerUnit) * pointsPerUnit;
+}
+
+function buildRedemptionModal(
+  currentBalance = null,
+  stadiumConfig = config.stadium,
+) {
+  validateConversionConfiguration(stadiumConfig);
+  const hasCurrentBalance = Number.isSafeInteger(currentBalance);
+  const configuredMaximum = stadiumConfig.maximumFistbumps;
+  const effectiveMaximum = hasCurrentBalance
+    ? configuredMaximum !== null
+      ? Math.min(currentBalance, configuredMaximum)
+      : currentBalance
+    : configuredMaximum;
+  const balanceText = hasCurrentBalance
+    ? `\n*Balance:* ${currentBalance} fistbumps`
+    : "\nYour available balance will be checked when you submit.";
+  return {
+    type: "modal",
+    callback_id: "stadium_redeem_submit",
+    title: { type: "plain_text", text: "Stadium redemption" },
+    submit: { type: "plain_text", text: "Redeem" },
+    close: { type: "plain_text", text: "Cancel" },
+    blocks: [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `Exchange fistbumps for Stadium points, then use your Liatrio SSO account at Stadium.${balanceText}\n*Rate:* ${stadiumConfig.fistbumpsPerUnit} fistbump(s) = ${stadiumConfig.pointsPerUnit} Stadium point(s)`,
+        },
+      },
+      {
+        type: "input",
+        block_id: "stadium_amount",
+        label: { type: "plain_text", text: "Fistbumps to redeem" },
+        element: {
+          type: "number_input",
+          action_id: "stadium_amount_value",
+          is_decimal_allowed: false,
+          min_value: String(stadiumConfig.minimumFistbumps),
+          ...(effectiveMaximum !== null &&
+          effectiveMaximum >= stadiumConfig.minimumFistbumps
+            ? { max_value: String(effectiveMaximum) }
+            : {}),
+        },
+      },
+    ],
+  };
+}
+
+function resultFromCurrentRecord(record, id, fulfillment = {}) {
+  if (record?.status === "needs_review") {
+    return { status: "needs_review", id };
+  }
+  if (["failed", "refunded"].includes(record?.status)) {
+    if (fulfillment.orderNumber) {
+      return {
+        status: "resolution_conflict",
+        id,
+        terminalStatus: record.status,
+        ...fulfillment,
+      };
+    }
+    return { status: "failed", id };
+  }
+  if (record?.status === "fulfilled") {
+    return {
+      status: "fulfilled",
+      id,
+      stadiumPoints: record.stadiumPoints,
+      orderNumber: record.stadium?.orderNumber || fulfillment.orderNumber,
+      paymentState: record.stadium?.paymentState || fulfillment.paymentState,
+    };
+  }
+  throw new StadiumError(
+    "Stadium redemption state changed unexpectedly.",
+    "ambiguous",
+    { redemptionId: id },
+  );
+}
+
+async function recordLateFulfillment(id, fulfillment, stadiumPoints) {
+  const now = new Date();
+  const update = {
+    status: "fulfilled",
+    updatedAt: now,
+    stadium: fulfillment,
+    lateConfirmationAt: now,
+  };
+  const fulfilled = await deductionCollection.updateOne(
+    { _id: id, status: "needs_review" },
+    { $set: update },
+  );
+  if (fulfilled.modifiedCount) {
+    return { status: "fulfilled", stadium: fulfillment, stadiumPoints };
+  }
+
+  const current = await deductionCollection.findOne({ _id: id });
+  if (current?.status === "fulfilled" && !current.stadium?.orderNumber) {
+    await deductionCollection.updateOne(
+      { _id: id, status: "fulfilled" },
+      { $set: { stadium: fulfillment, lateConfirmationAt: now } },
+    );
+    current.stadium = fulfillment;
+  }
+  if (["failed", "refunded"].includes(current?.status)) {
+    winston.error("Late Stadium fulfillment conflicts with terminal state", {
+      func: "service.stadium.recordLateFulfillment",
+      redemptionId: id,
+      terminalStatus: current.status,
+      orderNumber: fulfillment.orderNumber,
+    });
+  }
+  return current;
+}
+
+async function request(path, options, classification, stadiumConfig) {
+  let response;
+  try {
+    response = await fetch(`${stadiumConfig.apiBaseUrl}${path}`, {
+      ...options,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new StadiumError(
+      `Stadium request did not complete: ${error.message}`,
+      classification,
+    );
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  return { response, body };
+}
+
+async function getAccessToken(stadiumConfig = config.stadium) {
+  if (tokenCache && tokenCache.expiresAt > Date.now() + 60000) {
+    return tokenCache.value;
+  }
+  validateConfiguration(stadiumConfig);
+  const { response, body } = await request(
+    "/oauth/token",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_id: stadiumConfig.clientId,
+        client_secret: stadiumConfig.clientSecret,
+      }),
+    },
+    "definite",
+    stadiumConfig,
+  );
+  if (!response.ok || !body?.token) {
+    throw new StadiumError("Stadium authentication failed.", "definite", {
+      httpStatus: response.status,
+    });
+  }
+  const expiresAt = body.expires_at
+    ? Number(body.expires_at) * 1000
+    : Date.now() + Number(body.expires_in || 3600) * 1000;
+  tokenCache = { value: body.token, expiresAt };
+  return tokenCache.value;
+}
+
+async function sendPoints(
+  { email, points, redemptionId },
+  stadiumConfig = config.stadium,
+) {
+  const token = await getAccessToken(stadiumConfig);
+  const payload = {
+    store_number: stadiumConfig.storeNumber,
+    contact_emails: email,
+    organizer_share: points,
+    expected_count: 1,
+    send_shop_points: true,
+    treat_name: `Gratibot redemption ${redemptionId}`,
+    rlp_message: "Points redeemed from Gratibot fistbumps.",
+    payment_method: stadiumConfig.paymentMethod
+      .split(",")
+      .map((method) => method.trim()),
+    auto_accept_points: true,
+    billing_country: stadiumConfig.billingCountry,
+    billing_zipcode: stadiumConfig.billingZipcode,
+  };
+  const { response, body } = await request(
+    "/send_points",
+    {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+    "ambiguous",
+    stadiumConfig,
+  );
+
+  if (!response.ok) {
+    if (response.status === 401) tokenCache = null;
+    const classification =
+      response.status >= 400 && response.status < 500 && response.status !== 429
+        ? "definite"
+        : "ambiguous";
+    throw new StadiumError(
+      "Stadium rejected the points request.",
+      classification,
+      {
+        httpStatus: response.status,
+      },
+    );
+  }
+  if (!body?.number || body.payment_state !== "paid") {
+    throw new StadiumError(
+      "Stadium returned an unconfirmed fulfillment response.",
+      "ambiguous",
+      { orderNumber: body?.number, paymentState: body?.payment_state },
+    );
+  }
+  return { orderNumber: body.number, paymentState: body.payment_state };
+}
+
+async function redeem({ user, email, fistbumps, redemptionId }) {
+  const stadiumPoints = fistbumpsToPoints(fistbumps);
+  const corporateEmail = normalizeCorporateEmail(email);
+  const id = `stadium:${redemptionId}`;
+  const lockResult = await deduction.acquireLock(user, id, {
+    kind: "stadium-in-flight",
+  });
+  if (!lockResult.acquired) {
+    return {
+      status: "busy",
+      reason: lockResult.reason,
+      operationId: lockResult.operationId,
+    };
+  }
+
+  let inserted = false;
+  let dispatchStarted = false;
+  try {
+    if ((await balance.currentBalance(user)) < fistbumps) {
+      await deduction.releaseLock(user, id);
+      return { status: "insufficient" };
+    }
+    const now = new Date();
+    await deductionCollection.insertOne({
+      _id: id,
+      source: "stadium",
+      status: "reserved",
+      user,
+      corporateEmail,
+      value: fistbumps,
+      stadiumPoints,
+      ratio: {
+        fistbumpsPerUnit: config.stadium.fistbumpsPerUnit,
+        pointsPerUnit: config.stadium.pointsPerUnit,
+      },
+      refund: false,
+      timestamp: now,
+      updatedAt: now,
+    });
+    inserted = true;
+    const sending = await deductionCollection.updateOne(
+      { _id: id, status: "reserved" },
+      { $set: { status: "sending", updatedAt: new Date() } },
+    );
+    if (!sending.modifiedCount) {
+      const current = await deductionCollection.findOne({ _id: id });
+      await deduction.releaseLock(user, id);
+      return resultFromCurrentRecord(current, id);
+    }
+    dispatchStarted = true;
+    const fulfillment = await sendPoints({
+      email: corporateEmail,
+      points: stadiumPoints,
+      redemptionId: id,
+    });
+    const fulfilled = await deductionCollection.updateOne(
+      { _id: id, status: "sending" },
+      {
+        $set: {
+          status: "fulfilled",
+          updatedAt: new Date(),
+          stadium: fulfillment,
+        },
+      },
+    );
+    if (!fulfilled.modifiedCount) {
+      const current = await recordLateFulfillment(
+        id,
+        fulfillment,
+        stadiumPoints,
+      );
+      await deduction.releaseLock(user, id);
+      return resultFromCurrentRecord(current, id, fulfillment);
+    }
+    await deduction.releaseLock(user, id);
+    return { status: "fulfilled", id, stadiumPoints, ...fulfillment };
+  } catch (error) {
+    if (!inserted) {
+      await deduction.releaseLock(user, id);
+      if (error.code === 11000) return { status: "duplicate", id };
+      throw error;
+    }
+    const classification =
+      error.classification || (dispatchStarted ? "ambiguous" : "definite");
+    const nextStatus =
+      classification === "definite" ? "failed" : "needs_review";
+    const transitionTime = new Date();
+    const update = {
+      status: nextStatus,
+      updatedAt: transitionTime,
+      ...(classification === "definite" ? { refund: true } : {}),
+      ...(classification === "ambiguous"
+        ? {
+            reviewNotification: {
+              nextAttemptAt: transitionTime,
+            },
+          }
+        : {}),
+      ...(error.details !== undefined ? { stadium: error.details } : {}),
+    };
+    const transitionableStatuses = dispatchStarted
+      ? ["sending"]
+      : ["reserved", "sending"];
+    const transitioned = await deductionCollection.updateOne(
+      { _id: id, status: { $in: transitionableStatuses } },
+      { $set: update },
+    );
+    if (!transitioned.modifiedCount) {
+      const current = await deductionCollection.findOne({ _id: id });
+      await deduction.releaseLock(user, id);
+      return resultFromCurrentRecord(current, id);
+    }
+    if (classification === "definite") {
+      await deduction.releaseLock(user, id);
+      return { status: "failed", id };
+    }
+    winston.error("Stadium fulfillment needs admin review", {
+      func: "service.stadium.redeem",
+      callingUser: user,
+      redemptionId: id,
+      error: error.message,
+    });
+    await deduction.releaseLock(user, id);
+    return { status: "needs_review", id };
+  }
+}
+
+async function reviewRedemptions() {
+  return deductionCollection
+    .find({ source: "stadium", status: "needs_review" })
+    .sort({ timestamp: 1 })
+    .toArray();
+}
+
+function reviewNotificationDueFilter(now) {
+  return {
+    source: "stadium",
+    status: "needs_review",
+    "reviewNotification.notifiedAt": { $exists: false },
+    $and: [
+      {
+        $or: [
+          { "reviewNotification.nextAttemptAt": { $exists: false } },
+          { "reviewNotification.nextAttemptAt": { $lte: now } },
+        ],
+      },
+      {
+        $or: [
+          { "reviewNotification.claimUntil": { $exists: false } },
+          { "reviewNotification.claimUntil": { $lte: now } },
+        ],
+      },
+    ],
+  };
+}
+
+async function claimReviewNotification(id, now = new Date()) {
+  const claimId = randomUUID();
+  const record = await deductionCollection.findOneAndUpdate(
+    { _id: id, ...reviewNotificationDueFilter(now) },
+    {
+      $set: {
+        "reviewNotification.claimId": claimId,
+        "reviewNotification.claimUntil": new Date(
+          now.getTime() + REVIEW_NOTIFICATION_CLAIM_MS,
+        ),
+        "reviewNotification.lastAttemptAt": now,
+      },
+    },
+    { returnDocument: "after" },
+  );
+  return record ? { record, claimId } : null;
+}
+
+async function claimReviewNotifications(now = new Date()) {
+  const records = await deductionCollection
+    .find(reviewNotificationDueFilter(now))
+    .toArray();
+  const claims = await Promise.all(
+    records.map((record) => claimReviewNotification(record._id, now)),
+  );
+  return claims.filter(Boolean);
+}
+
+async function completeReviewNotification(
+  id,
+  claimId,
+  delivered,
+  now = new Date(),
+) {
+  const update = delivered
+    ? {
+        $set: { "reviewNotification.notifiedAt": now },
+        $unset: {
+          "reviewNotification.claimId": "",
+          "reviewNotification.claimUntil": "",
+          "reviewNotification.nextAttemptAt": "",
+        },
+      }
+    : {
+        $set: {
+          "reviewNotification.nextAttemptAt": new Date(
+            now.getTime() + REVIEW_NOTIFICATION_RETRY_MS,
+          ),
+        },
+        $unset: {
+          "reviewNotification.claimId": "",
+          "reviewNotification.claimUntil": "",
+        },
+      };
+  return deductionCollection.updateOne(
+    {
+      _id: id,
+      source: "stadium",
+      status: "needs_review",
+      "reviewNotification.claimId": claimId,
+    },
+    update,
+  );
+}
+
+async function resolveRedemption(id, resolution, admin) {
+  if (!["fulfilled", "refund"].includes(resolution)) {
+    return { status: "invalid" };
+  }
+  const record = await deductionCollection.findOne({
+    _id: id,
+    source: "stadium",
+    status: "needs_review",
+  });
+  if (!record) return { status: "not_found" };
+  const now = new Date();
+  const nextStatus = resolution === "refund" ? "refunded" : "fulfilled";
+  const result = await deductionCollection.updateOne(
+    { _id: id, status: "needs_review" },
+    {
+      $set: {
+        status: nextStatus,
+        refund: resolution === "refund",
+        updatedAt: now,
+        resolution: { admin, action: resolution, timestamp: now },
+      },
+    },
+  );
+  if (!result.modifiedCount) return { status: "not_found" };
+  await deduction.releaseLock(record.user, id, { force: true });
+  return { status: nextStatus, record };
+}
+
+async function reconcilePending() {
+  const now = new Date();
+  const staleBefore = new Date(now.getTime() - deduction.LOCK_LEASE_MS);
+  const reserved = await deductionCollection
+    .find({
+      source: "stadium",
+      status: "reserved",
+      updatedAt: { $lte: staleBefore },
+    })
+    .toArray();
+  const refundedRecords = [];
+  for (const record of reserved) {
+    const result = await deductionCollection.updateOne(
+      { _id: record._id, status: "reserved", updatedAt: record.updatedAt },
+      { $set: { status: "failed", refund: true, updatedAt: now } },
+    );
+    if (result.modifiedCount) {
+      await deduction.releaseLock(record.user, record._id, { force: true });
+      refundedRecords.push(record);
+    }
+  }
+  const sending = await deductionCollection
+    .find({
+      source: "stadium",
+      status: "sending",
+      updatedAt: { $lte: staleBefore },
+    })
+    .toArray();
+  const needsReviewRecords = [];
+  for (const record of sending) {
+    const result = await deductionCollection.updateOne(
+      { _id: record._id, status: "sending", updatedAt: record.updatedAt },
+      {
+        $set: {
+          status: "needs_review",
+          updatedAt: now,
+          reviewNotification: { nextAttemptAt: now },
+        },
+      },
+    );
+    if (result.modifiedCount) {
+      await deduction.releaseLock(record.user, record._id, { force: true });
+      needsReviewRecords.push(record);
+    }
+  }
+  await deduction.cleanupLegacyReviewLocks();
+  await deduction.cleanupExpiredLocks(now);
+  return {
+    refunded: refundedRecords.length,
+    needsReview: needsReviewRecords.length,
+    refundedRecords,
+    needsReviewRecords,
+  };
+}
+
+function resetTokenCache() {
+  tokenCache = null;
+}
+
+module.exports = {
+  StadiumError,
+  normalizeCorporateEmail,
+  fistbumpsToPoints,
+  buildRedemptionModal,
+  getAccessToken,
+  sendPoints,
+  redeem,
+  reviewRedemptions,
+  claimReviewNotification,
+  claimReviewNotifications,
+  completeReviewNotification,
+  resolveRedemption,
+  reconcilePending,
+  resetTokenCache,
+};

--- a/slack_app_manifest.yml
+++ b/slack_app_manifest.yml
@@ -33,6 +33,7 @@ oauth_config:
       - reactions:write
       - usergroups:read
       - users:read
+      - users:read.email
 settings:
   event_subscriptions:
     bot_events:

--- a/test/features/deduction.js
+++ b/test/features/deduction.js
@@ -33,6 +33,8 @@ describe("features/deduction", () => {
 
   beforeEach(() => {
     originalAdmins = [...config.redemptionAdmins];
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
   });
 
   afterEach(() => {
@@ -172,9 +174,7 @@ describe("features/deduction", () => {
       const handler = findHandler("message", /deduct/i);
 
       sinon.stub(deduction, "isBalanceSufficient").resolves(true);
-      sinon
-        .stub(deduction, "createDeduction")
-        .resolves({ _id: "DEDUCTION-123" });
+      sinon.stub(deduction, "createDeduction").resolves("DEDUCTION-123");
 
       const client = buildClient();
       const message = {
@@ -197,6 +197,36 @@ describe("features/deduction", () => {
         "A deduction of 5 fistbumps has been made for <@Uother>",
       );
       expect(args.text).to.include("DEDUCTION-123");
+    });
+
+    it("should tell an admin when a Stadium review blocks a deduction", async () => {
+      setAdmins(["Uadmin"]);
+      const { app, findHandler } = createMockApp();
+      deductionFeature(app);
+      const handler = findHandler("message", /deduct/i);
+      deduction.acquireLock.resolves({
+        acquired: false,
+        reason: "stadium-review",
+        operationId: "stadium:T1:V1",
+      });
+      const client = buildClient();
+
+      await handler({
+        message: {
+          user: "Uadmin",
+          text: "<@Ugratibot> deduct <@Uother> 5",
+          channel: "Ddm",
+          channel_type: "im",
+        },
+        client,
+      });
+
+      expect(client.chat.postMessage.firstCall.args[0].text).to.include(
+        "stadium:T1:V1",
+      );
+      expect(client.chat.postMessage.firstCall.args[0].text).to.include(
+        "stadium review",
+      );
     });
   });
 });

--- a/test/features/redeem.js
+++ b/test/features/redeem.js
@@ -23,6 +23,11 @@ function buildClient() {
 const USER_REDEEM_MATCHER = /redeem/i;
 
 describe("features/redeem", () => {
+  beforeEach(() => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+  });
+
   afterEach(() => {
     sinon.restore();
   });
@@ -166,6 +171,28 @@ describe("features/redeem", () => {
       expect(text).to.include("Please provide the link");
     });
 
+    it("should retain the balance guard for a priced Liatrio Store reward", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R-store",
+        name: "Liatrio Store",
+        cost: 20,
+        kind: "liatrio-store",
+      });
+      sinon.stub(deduction, "isBalanceSufficient").resolves(false);
+      const client = buildClient();
+      await actionHandler({
+        ack: sinon.stub().resolves(),
+        body: bodyWithRewardId("R-store"),
+        context: { botToken: "xoxb" },
+        client,
+      });
+      expect(client.conversations.open.called).to.equal(false);
+      expect(client.chat.postEphemeral.calledOnce).to.equal(true);
+    });
+
     it("should call createDeduction for a regular (non-Liatrio-Store) kind", async () => {
       const { app, findHandler } = createMockApp();
       redeemFeature(app);
@@ -263,6 +290,35 @@ describe("features/redeem", () => {
       expect(client.chat.postEphemeral.calledOnce).to.equal(true);
       expect(client.chat.postEphemeral.firstCall.args[0].text).to.include(
         "Your current balance isn't high enough",
+      );
+    });
+
+    it("should explain when a Stadium review blocks another reward", async () => {
+      const { app, findHandler } = createMockApp();
+      redeemFeature(app);
+      const actionHandler = findHandler("action", { action_id: "redeem" });
+      sinon.stub(redeem, "fetchActiveRewardById").resolves({
+        _id: "R-review",
+        name: "Sticker",
+        cost: 5,
+        kind: null,
+      });
+      deduction.acquireLock.resolves({
+        acquired: false,
+        reason: "stadium-review",
+        operationId: "stadium:T1:V1",
+      });
+      const client = buildClient();
+
+      await actionHandler({
+        ack: sinon.stub().resolves(),
+        body: bodyWithRewardId("R-review"),
+        context: { botToken: "xoxb" },
+        client,
+      });
+
+      expect(client.chat.postEphemeral.firstCall.args[0].text).to.include(
+        "awaiting admin review",
       );
     });
 

--- a/test/features/refund.js
+++ b/test/features/refund.js
@@ -10,11 +10,26 @@ describe("features/refund", () => {
     sinon.restore();
   });
 
-  it("should register refund.respondToRefund against the /refund/i message matcher", () => {
-    const { app, findHandler } = createMockApp();
+  it("registers multiline generic refunds without capturing Stadium resolution", () => {
+    const { app, registrations, findHandler } = createMockApp();
     refundFeature(app);
 
-    const handler = findHandler("message", /refund/i);
+    const handler = findHandler(
+      "message",
+      /^(?!.*\bstadium\s+resolve\b.*\brefund\b).*\brefund\b/is,
+    );
     expect(handler).to.equal(refund.respondToRefund);
+    const matcher = registrations.message[0].matchers[0];
+    expect(
+      matcher.test("Refunding this one:\nrefund 62171d78b5daaa0011771cfd"),
+    ).to.equal(true);
+    expect(matcher.test("stadium resolve stadium:T1:V1\nrefund")).to.equal(
+      false,
+    );
+    expect(
+      matcher.test(
+        "refund 62171d78b5daaa0011771cfd — not the stadium resolve path",
+      ),
+    ).to.equal(true);
   });
 });

--- a/test/features/stadium-redeem.js
+++ b/test/features/stadium-redeem.js
@@ -1,0 +1,441 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const config = require("../../config");
+const stadiumFeature = require("../../features/stadium-redeem");
+const stadium = require("../../service/stadium");
+const { createMockApp } = require("../mocks/bolt-app");
+
+function client() {
+  return {
+    views: { open: sinon.stub().resolves() },
+    users: {
+      info: sinon.stub().resolves({
+        ok: true,
+        user: { profile: { email: "person@liatrio.com" } },
+      }),
+    },
+    chat: {
+      postMessage: sinon.stub().resolves(),
+      postEphemeral: sinon.stub().resolves(),
+    },
+  };
+}
+
+function submission(amount = "5") {
+  return {
+    body: { user: { id: "U1" }, team: { id: "T1" } },
+    view: {
+      id: "V1",
+      state: {
+        values: {
+          stadium_amount: {
+            stadium_amount_value: { value: amount },
+          },
+        },
+      },
+    },
+  };
+}
+
+describe("features/stadium-redeem", () => {
+  let originalEnabled;
+  let originalRatio;
+  let originalAdmins;
+
+  beforeEach(() => {
+    originalEnabled = config.stadium.enabled;
+    originalRatio = {
+      fistbumpsPerUnit: config.stadium.fistbumpsPerUnit,
+      pointsPerUnit: config.stadium.pointsPerUnit,
+      minimumFistbumps: config.stadium.minimumFistbumps,
+      maximumFistbumps: config.stadium.maximumFistbumps,
+    };
+    originalAdmins = [...config.redemptionAdmins];
+    Object.assign(config.stadium, {
+      enabled: true,
+      fistbumpsPerUnit: 1,
+      pointsPerUnit: 1,
+      minimumFistbumps: 1,
+      maximumFistbumps: null,
+    });
+  });
+
+  afterEach(() => {
+    config.stadium.enabled = originalEnabled;
+    Object.assign(config.stadium, originalRatio);
+    config.redemptionAdmins.splice(
+      0,
+      config.redemptionAdmins.length,
+      ...originalAdmins,
+    );
+    sinon.restore();
+  });
+
+  it("opens the redemption modal without waiting for a balance query", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("action", {
+      action_id: "stadium_redeem_open",
+    });
+    sinon.stub(stadium, "buildRedemptionModal").returns({ type: "modal" });
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    await handler({
+      ack,
+      body: { user: { id: "U1" }, trigger_id: "trigger" },
+      client: slack,
+    });
+    expect(ack.calledBefore(slack.views.open)).to.equal(true);
+    sinon.assert.calledWith(slack.views.open, {
+      trigger_id: "trigger",
+      view: { type: "modal" },
+    });
+    sinon.assert.calledWithExactly(stadium.buildRedemptionModal);
+  });
+
+  it("notifies the user when a stale redemption button is disabled", async () => {
+    config.stadium.enabled = false;
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("action", {
+      action_id: "stadium_redeem_open",
+    });
+    const slack = client();
+    const ack = sinon.stub().resolves();
+
+    await handler({
+      ack,
+      body: { user: { id: "U1" }, trigger_id: "trigger" },
+      client: slack,
+    });
+
+    expect(ack.calledOnce).to.equal(true);
+    expect(slack.views.open.called).to.equal(false);
+    expect(slack.chat.postMessage.firstCall.args[0]).to.include({
+      channel: "U1",
+      text: "Stadium redemption is currently unavailable.",
+    });
+  });
+
+  it("notifies the user when the redemption modal cannot be opened", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("action", {
+      action_id: "stadium_redeem_open",
+    });
+    const slack = client();
+    slack.views.open.rejects(new Error("expired_trigger_id"));
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      body: { user: { id: "U1" }, trigger_id: "trigger" },
+      client: slack,
+    });
+
+    expect(slack.chat.postMessage.firstCall.args[0]).to.include({
+      channel: "U1",
+    });
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "couldn't open",
+    );
+  });
+
+  it("keeps the modal open with a validation error for an invalid amount", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const ack = sinon.stub().resolves();
+    await handler({ ack, client: client(), ...submission("1.5") });
+    expect(ack.firstCall.args[0]).to.deep.include({
+      response_action: "errors",
+    });
+  });
+
+  it("rejects a stale modal submission when the integration is disabled", async () => {
+    config.stadium.enabled = false;
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+    expect(slack.users.info.called).to.equal(false);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "currently unavailable",
+    );
+  });
+
+  it("reads Slack email and fulfills with a deterministic view id", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "fulfilled",
+      stadiumPoints: 5,
+      orderNumber: "ORDER",
+    });
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    await handler({ ack, client: slack, ...submission() });
+    expect(ack.calledOnce).to.equal(true);
+    sinon.assert.calledWith(stadium.redeem, {
+      user: "U1",
+      email: "person@liatrio.com",
+      fistbumps: 5,
+      redemptionId: "T1:V1",
+    });
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "5 Stadium points",
+    );
+  });
+
+  it("does not expose internal errors to the user", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon
+      .stub(stadium, "redeem")
+      .rejects(new Error("mongodb://internal-host secret detail"));
+    const slack = client();
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+    const text = slack.chat.postMessage.firstCall.args[0].text;
+    expect(text).to.include("couldn't confirm the final status");
+    expect(text).not.to.include("mongodb");
+    expect(text).not.to.include("secret detail");
+  });
+
+  it("does not describe a completed redemption as unsubmitted when notification fails", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "fulfilled",
+      id: "stadium:T1:V1",
+      stadiumPoints: 5,
+      orderNumber: "ORDER",
+    });
+    const slack = client();
+    slack.chat.postMessage.onFirstCall().rejects(new Error("slack failed"));
+    slack.chat.postMessage.onSecondCall().resolves();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+
+    expect(slack.chat.postMessage.secondCall.args[0].text).to.include(
+      "was processed",
+    );
+    expect(slack.chat.postMessage.secondCall.args[0].text).not.to.include(
+      "not lost",
+    );
+  });
+
+  it("surfaces the safe corporate-email requirement", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").rejects(
+      new stadium.StadiumError("internal validation detail", "definite", {
+        userMessage:
+          "Stadium redemption requires a liatrio.com email in your Slack profile.",
+      }),
+    );
+    const slack = client();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.equal(
+      "Stadium redemption requires a liatrio.com email in your Slack profile.",
+    );
+  });
+
+  it("does not describe a Slack profile lookup failure as uncertain", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    slack.users.info.rejects(new Error("missing_scope"));
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+
+    sinon.assert.notCalled(redeem);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "couldn't read your corporate email",
+    );
+    expect(slack.chat.postMessage.firstCall.args[0].text).not.to.include(
+      "final status",
+    );
+  });
+
+  it("notifies the user and admins when fulfillment needs review", async () => {
+    config.redemptionAdmins.splice(0, config.redemptionAdmins.length, "UA");
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "needs_review",
+      id: "stadium:T1:V1",
+    });
+    sinon
+      .stub(stadium, "claimReviewNotification")
+      .resolves({ claimId: "claim-1" });
+    const completeNotification = sinon
+      .stub(stadium, "completeReviewNotification")
+      .resolves({ modifiedCount: 1 });
+    const slack = client();
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+    expect(slack.chat.postMessage.callCount).to.equal(2);
+    expect(slack.chat.postMessage.secondCall.args[0]).to.include({
+      channel: "UA",
+    });
+    expect(slack.chat.postMessage.secondCall.args[0].text).to.include(
+      "stadium resolve stadium:T1:V1 fulfilled",
+    );
+    expect(slack.chat.postMessage.secondCall.args[0].text).to.include(
+      "stadium resolve stadium:T1:V1 refund",
+    );
+    sinon.assert.calledWith(
+      completeNotification,
+      "stadium:T1:V1",
+      "claim-1",
+      true,
+    );
+  });
+
+  it("notifies the user and admins about a late fulfillment conflict", async () => {
+    config.redemptionAdmins.splice(0, config.redemptionAdmins.length, "UA");
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "resolution_conflict",
+      id: "stadium:T1:V1",
+      terminalStatus: "refunded",
+      orderNumber: "ORDER",
+    });
+    const slack = client();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "confirmed the points",
+    );
+    expect(slack.chat.postMessage.secondCall.args[0]).to.include({
+      channel: "UA",
+    });
+    expect(slack.chat.postMessage.secondCall.args[0].text).to.include("ORDER");
+  });
+
+  it("lists unresolved redemptions for admins", async () => {
+    config.redemptionAdmins.splice(0, config.redemptionAdmins.length, "UA");
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("message", /\bstadium review\b/i);
+    sinon
+      .stub(stadium, "reviewRedemptions")
+      .resolves([{ _id: "stadium:T:V", user: "U1", value: 5 }]);
+    const slack = client();
+    await handler({
+      message: {
+        user: "UA",
+        channel: "D1",
+        channel_type: "im",
+        text: "stadium review",
+      },
+      client: slack,
+    });
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "stadium:T:V",
+    );
+  });
+
+  it("resolves an uncertain redemption and informs its owner", async () => {
+    config.redemptionAdmins.splice(0, config.redemptionAdmins.length, "UA");
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler(
+      "message",
+      /^(?!.*\brefund\b.*\bstadium\s+resolve\b).*\bstadium\s+resolve\b/is,
+    );
+    sinon.stub(stadium, "resolveRedemption").resolves({
+      status: "refunded",
+      record: { user: "U1" },
+    });
+    const slack = client();
+    await handler({
+      message: {
+        user: "UA",
+        channel: "D1",
+        channel_type: "im",
+        text: "stadium resolve stadium:T:V refund",
+      },
+      client: slack,
+    });
+    sinon.assert.calledWith(
+      stadium.resolveRedemption,
+      "stadium:T:V",
+      "refund",
+      "UA",
+    );
+    expect(slack.chat.postMessage.secondCall.args[0]).to.include({
+      channel: "U1",
+    });
+  });
+
+  it("accepts a review id copied with backticks", async () => {
+    config.redemptionAdmins.splice(0, config.redemptionAdmins.length, "UA");
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler(
+      "message",
+      /^(?!.*\brefund\b.*\bstadium\s+resolve\b).*\bstadium\s+resolve\b/is,
+    );
+    sinon.stub(stadium, "resolveRedemption").resolves({
+      status: "fulfilled",
+    });
+
+    await handler({
+      message: {
+        user: "UA",
+        channel: "D1",
+        channel_type: "im",
+        text: "stadium resolve `stadium:T:V` fulfilled",
+      },
+      client: client(),
+    });
+
+    sinon.assert.calledWith(
+      stadium.resolveRedemption,
+      "stadium:T:V",
+      "fulfilled",
+      "UA",
+    );
+  });
+});

--- a/test/features/stadium-redeem.js
+++ b/test/features/stadium-redeem.js
@@ -22,17 +22,28 @@ function client() {
   };
 }
 
-function submission(amount = "5") {
+function submission(
+  amount = "5",
+  email = "person@liatrio.com",
+  emailSource = "modal",
+) {
+  const values = {
+    stadium_amount: {
+      stadium_amount_value: { value: amount },
+    },
+  };
+  if (emailSource === "modal") {
+    values.stadium_email = {
+      stadium_email_value: { value: email },
+    };
+  }
   return {
     body: { user: { id: "U1" }, team: { id: "T1" } },
     view: {
       id: "V1",
+      private_metadata: JSON.stringify({ emailSource }),
       state: {
-        values: {
-          stadium_amount: {
-            stadium_amount_value: { value: amount },
-          },
-        },
+        values,
       },
     },
   };
@@ -50,10 +61,14 @@ describe("features/stadium-redeem", () => {
       pointsPerUnit: config.stadium.pointsPerUnit,
       minimumFistbumps: config.stadium.minimumFistbumps,
       maximumFistbumps: config.stadium.maximumFistbumps,
+      emailSource: config.stadium.emailSource,
+      storeUrl: config.stadium.storeUrl,
     };
     originalAdmins = [...config.redemptionAdmins];
     Object.assign(config.stadium, {
       enabled: true,
+      emailSource: "modal",
+      storeUrl: "https://stadium.example/",
       fistbumpsPerUnit: 1,
       pointsPerUnit: 1,
       minimumFistbumps: 1,
@@ -141,6 +156,30 @@ describe("features/stadium-redeem", () => {
     );
   });
 
+  it("surfaces a specific configuration error when the modal cannot be built", async () => {
+    config.stadium.emailSource = "invalid";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("action", {
+      action_id: "stadium_redeem_open",
+    });
+    const slack = client();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      body: { user: { id: "U1" }, trigger_id: "trigger" },
+      client: slack,
+    });
+
+    expect(slack.views.open.called).to.equal(false);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "email settings are invalid",
+    );
+    expect(slack.chat.postMessage.firstCall.args[0].text).not.to.include(
+      "try again",
+    );
+  });
+
   it("keeps the modal open with a validation error for an invalid amount", async () => {
     const { app, findHandler } = createMockApp();
     stadiumFeature(app);
@@ -150,6 +189,30 @@ describe("features/stadium-redeem", () => {
     expect(ack.firstCall.args[0]).to.deep.include({
       response_action: "errors",
     });
+    expect(ack.firstCall.args[0].errors).to.have.property("stadium_amount");
+  });
+
+  it("keeps the modal open with all manual-input validation errors", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const ack = sinon.stub().resolves();
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({
+      ack,
+      client: client(),
+      ...submission("1.5", "person@example.com"),
+    });
+
+    expect(ack.firstCall.args[0]).to.deep.equal({
+      response_action: "errors",
+      errors: {
+        stadium_amount: "Enter a valid whole-number fistbump amount.",
+        stadium_email: "Enter a valid @liatrio.com email address.",
+      },
+    });
+    sinon.assert.notCalled(redeem);
   });
 
   it("rejects a stale modal submission when the integration is disabled", async () => {
@@ -169,7 +232,106 @@ describe("features/stadium-redeem", () => {
     );
   });
 
-  it("reads Slack email and fulfills with a deterministic view id", async () => {
+  it("fails closed when the email source is invalid", async () => {
+    config.stadium.emailSource = "fallback";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({ ack, client: slack, ...submission() });
+
+    expect(ack.calledOnce).to.equal(true);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "email settings are invalid",
+    );
+    sinon.assert.notCalled(redeem);
+  });
+
+  it("rejects a stale Slack-source modal after settings switch to modal", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    const redeem = sinon.stub(stadium, "redeem");
+    const stale = submission("5", undefined, "slack");
+
+    await handler({ ack, client: slack, ...stale });
+
+    expect(ack.calledWithExactly()).to.equal(true);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "settings changed",
+    );
+    sinon.assert.notCalled(slack.users.info);
+    sinon.assert.notCalled(redeem);
+  });
+
+  it("supports a legacy modal without email-source metadata", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    const legacy = submission();
+    delete legacy.view.private_metadata;
+    const redeem = sinon.stub(stadium, "redeem").resolves({
+      status: "fulfilled",
+      stadiumPoints: 5,
+    });
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...legacy,
+    });
+
+    sinon.assert.calledWith(redeem, {
+      user: "U1",
+      email: "person@liatrio.com",
+      fistbumps: 5,
+      redemptionId: "T1:V1",
+    });
+  });
+
+  it("rejects a stale modal-source modal after settings switch to Slack", async () => {
+    config.stadium.emailSource = "slack";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({ ack, client: slack, ...submission() });
+
+    expect(ack.calledWithExactly()).to.equal(true);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "settings changed",
+    );
+    sinon.assert.notCalled(slack.users.info);
+    sinon.assert.notCalled(redeem);
+  });
+
+  it("rejects invalid modal metadata and asks the user to reopen", async () => {
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    const ack = sinon.stub().resolves();
+    const invalid = submission();
+    invalid.view.private_metadata = "not-json";
+
+    await handler({ ack, client: slack, ...invalid });
+
+    expect(ack.calledWithExactly()).to.equal(true);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "no longer valid",
+    );
+  });
+
+  it("uses a normalized manual email without reading the Slack profile", async () => {
     const { app, findHandler } = createMockApp();
     stadiumFeature(app);
     const handler = findHandler("view", "stadium_redeem_submit");
@@ -180,8 +342,48 @@ describe("features/stadium-redeem", () => {
     });
     const slack = client();
     const ack = sinon.stub().resolves();
-    await handler({ ack, client: slack, ...submission() });
+    await handler({
+      ack,
+      client: slack,
+      ...submission("5", " Person@Liatrio.com "),
+    });
     expect(ack.calledOnce).to.equal(true);
+    sinon.assert.notCalled(slack.users.info);
+    sinon.assert.calledWith(stadium.redeem, {
+      user: "U1",
+      email: "person@liatrio.com",
+      fistbumps: 5,
+      redemptionId: "T1:V1",
+    });
+    const message = slack.chat.postMessage.firstCall.args[0].text;
+    expect(message).to.include(
+      "5 fistbumps were exchanged for 5 Stadium points and sent to person@liatrio.com.",
+    );
+    expect(message).to.include("Your Stadium gift is ready to redeem");
+    expect(message).to.include("<https://stadium.example/|Open Stadium>");
+    expect(message).to.include("select *Redeem Gift*");
+    expect(message).not.to.include("SSO");
+  });
+
+  it("retains automatic Slack email lookup when configured", async () => {
+    config.stadium.emailSource = "slack";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "fulfilled",
+      stadiumPoints: 5,
+      orderNumber: "ORDER",
+    });
+    const slack = client();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission("5", undefined, "slack"),
+    });
+
+    sinon.assert.calledWithExactly(slack.users.info, { user: "U1" });
     sinon.assert.calledWith(stadium.redeem, {
       user: "U1",
       email: "person@liatrio.com",
@@ -189,8 +391,31 @@ describe("features/stadium-redeem", () => {
       redemptionId: "T1:V1",
     });
     expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
-      "5 Stadium points",
+      "sent to person@liatrio.com",
     );
+  });
+
+  it("uses plain Open Stadium text when no store URL is configured", async () => {
+    config.stadium.storeUrl = "";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    sinon.stub(stadium, "redeem").resolves({
+      status: "fulfilled",
+      stadiumPoints: 5,
+    });
+    const slack = client();
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission(),
+    });
+
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "Open Stadium and select *Redeem Gift*",
+    );
+    expect(slack.chat.postMessage.firstCall.args[0].text).not.to.include("<");
   });
 
   it("does not expose internal errors to the user", async () => {
@@ -240,30 +465,29 @@ describe("features/stadium-redeem", () => {
     );
   });
 
-  it("surfaces the safe corporate-email requirement", async () => {
+  it("returns the safe corporate-email requirement inline", async () => {
     const { app, findHandler } = createMockApp();
     stadiumFeature(app);
     const handler = findHandler("view", "stadium_redeem_submit");
-    sinon.stub(stadium, "redeem").rejects(
-      new stadium.StadiumError("internal validation detail", "definite", {
-        userMessage:
-          "Stadium redemption requires a liatrio.com email in your Slack profile.",
-      }),
-    );
+    const redeem = sinon.stub(stadium, "redeem");
     const slack = client();
+    const ack = sinon.stub().resolves();
 
     await handler({
-      ack: sinon.stub().resolves(),
+      ack,
       client: slack,
-      ...submission(),
+      ...submission("5", "person@example.com"),
     });
 
-    expect(slack.chat.postMessage.firstCall.args[0].text).to.equal(
-      "Stadium redemption requires a liatrio.com email in your Slack profile.",
+    expect(ack.firstCall.args[0].errors.stadium_email).to.equal(
+      "Enter a valid @liatrio.com email address.",
     );
+    sinon.assert.notCalled(redeem);
+    sinon.assert.notCalled(slack.chat.postMessage);
   });
 
   it("does not describe a Slack profile lookup failure as uncertain", async () => {
+    config.stadium.emailSource = "slack";
     const { app, findHandler } = createMockApp();
     stadiumFeature(app);
     const handler = findHandler("view", "stadium_redeem_submit");
@@ -274,7 +498,7 @@ describe("features/stadium-redeem", () => {
     await handler({
       ack: sinon.stub().resolves(),
       client: slack,
-      ...submission(),
+      ...submission("5", undefined, "slack"),
     });
 
     sinon.assert.notCalled(redeem);
@@ -283,6 +507,53 @@ describe("features/stadium-redeem", () => {
     );
     expect(slack.chat.postMessage.firstCall.args[0].text).not.to.include(
       "final status",
+    );
+  });
+
+  it("directs an invalid Slack profile email back to the profile", async () => {
+    config.stadium.emailSource = "slack";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    slack.users.info.resolves({
+      ok: true,
+      user: { profile: { email: "person@example.com" } },
+    });
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission("5", undefined, "slack"),
+    });
+
+    sinon.assert.notCalled(redeem);
+    const message = slack.chat.postMessage.firstCall.args[0].text;
+    expect(message).to.include(
+      "Slack profile must contain a valid @liatrio.com email address",
+    );
+    expect(message).not.to.include("Enter a valid");
+  });
+
+  it("does not redeem when Slack returns no profile email", async () => {
+    config.stadium.emailSource = "slack";
+    const { app, findHandler } = createMockApp();
+    stadiumFeature(app);
+    const handler = findHandler("view", "stadium_redeem_submit");
+    const slack = client();
+    slack.users.info.resolves({ ok: true, user: { profile: {} } });
+    const redeem = sinon.stub(stadium, "redeem");
+
+    await handler({
+      ack: sinon.stub().resolves(),
+      client: slack,
+      ...submission("5", undefined, "slack"),
+    });
+
+    sinon.assert.notCalled(redeem);
+    expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
+      "couldn't read your corporate email",
     );
   });
 
@@ -345,7 +616,7 @@ describe("features/stadium-redeem", () => {
     });
 
     expect(slack.chat.postMessage.firstCall.args[0].text).to.include(
-      "confirmed the points",
+      "confirmed the paid order",
     );
     expect(slack.chat.postMessage.secondCall.args[0]).to.include({
       channel: "UA",

--- a/test/integration/bolt-wiring.js
+++ b/test/integration/bolt-wiring.js
@@ -12,9 +12,14 @@ const { NoOpReceiver } = require("../mocks/bolt-receiver");
 
 let balanceFeature;
 let recognizeFeature;
+let refundFeature;
+let stadiumFeature;
 let balance;
 let recognition;
 let apiwrappers;
+let deduction;
+let stadium;
+let config;
 let GratitudeError;
 
 function attachClientStubs(app) {
@@ -42,7 +47,12 @@ function attachClientStubs(app) {
   return stubs;
 }
 
-function makeApp({ withBalance = false, withRecognize = false } = {}) {
+function makeApp({
+  withBalance = false,
+  withRecognize = false,
+  withRefund = false,
+  withStadium = false,
+} = {}) {
   const app = new App({
     receiver: new NoOpReceiver(),
     token: "xoxb-test",
@@ -52,6 +62,8 @@ function makeApp({ withBalance = false, withRecognize = false } = {}) {
   });
   if (withBalance) balanceFeature(app);
   if (withRecognize) recognizeFeature(app);
+  if (withRefund) refundFeature(app);
+  if (withStadium) stadiumFeature(app);
   const stubs = attachClientStubs(app);
   return { app, stubs };
 }
@@ -80,9 +92,14 @@ describe("integration: bolt-wiring", function () {
   before(() => {
     balanceFeature = require("../../features/balance");
     recognizeFeature = require("../../features/recognize");
+    refundFeature = require("../../features/refund");
+    stadiumFeature = require("../../features/stadium-redeem");
     balance = require("../../service/balance");
     recognition = require("../../service/recognition");
     apiwrappers = require("../../service/apiwrappers");
+    deduction = require("../../service/deduction");
+    stadium = require("../../service/stadium");
+    config = require("../../config");
     ({ GratitudeError } = require("../../service/errors"));
   });
 
@@ -170,6 +187,156 @@ describe("integration: bolt-wiring", function () {
 
       expect(balance.currentBalance.callCount).to.equal(0);
       expect(stubs.postMessage.callCount).to.equal(0);
+    });
+  });
+
+  describe("refund command routing", () => {
+    it("keeps refund prose out of the Stadium resolution handler", async () => {
+      const originalAdmins = [...config.redemptionAdmins];
+      config.redemptionAdmins.splice(
+        0,
+        config.redemptionAdmins.length,
+        "Ucaller",
+      );
+      try {
+        const { app, stubs } = makeApp({
+          withRefund: true,
+          withStadium: true,
+        });
+        const genericRefund = sinon.stub(deduction, "refundDeduction");
+        const stadiumResolve = sinon.stub(stadium, "resolveRedemption");
+
+        await app.processEvent({
+          body: eventBody({
+            channelType: "im",
+            channel: "Ddm",
+            text: "refund 62171d78b5daaa0011771cfd — not the stadium resolve path",
+            ts: "2.0",
+            eventId: "Ev-refund-prose",
+          }),
+          ack: sinon.stub(),
+        });
+
+        sinon.assert.notCalled(genericRefund);
+        sinon.assert.notCalled(stadiumResolve);
+        expect(stubs.postMessage.callCount).to.equal(1);
+        expect(stubs.postMessage.firstCall.args[0].text).to.equal(
+          "Usage: `refund <deduction-id>`",
+        );
+      } finally {
+        config.redemptionAdmins.splice(
+          0,
+          config.redemptionAdmins.length,
+          ...originalAdmins,
+        );
+      }
+    });
+
+    it("routes a generic refund command after a newline", async () => {
+      const originalAdmins = [...config.redemptionAdmins];
+      config.redemptionAdmins.splice(
+        0,
+        config.redemptionAdmins.length,
+        "Ucaller",
+      );
+      try {
+        const { app } = makeApp({ withRefund: true });
+        const genericRefund = sinon
+          .stub(deduction, "refundDeduction")
+          .resolves({ status: "refunded" });
+
+        await app.processEvent({
+          body: eventBody({
+            channelType: "im",
+            channel: "Ddm",
+            text: "Refunding this one:\nrefund 62171d78b5daaa0011771cfd",
+            ts: "2.1",
+            eventId: "Ev-multiline-refund",
+          }),
+          ack: sinon.stub(),
+        });
+
+        sinon.assert.calledWith(genericRefund, "62171d78b5daaa0011771cfd");
+      } finally {
+        config.redemptionAdmins.splice(
+          0,
+          config.redemptionAdmins.length,
+          ...originalAdmins,
+        );
+      }
+    });
+
+    it("routes malformed refunds to the usage response", async () => {
+      const originalAdmins = [...config.redemptionAdmins];
+      config.redemptionAdmins.splice(
+        0,
+        config.redemptionAdmins.length,
+        "Ucaller",
+      );
+      try {
+        const { app, stubs } = makeApp({ withRefund: true });
+        const genericRefund = sinon.stub(deduction, "refundDeduction");
+
+        await app.processEvent({
+          body: eventBody({
+            channelType: "im",
+            channel: "Ddm",
+            text: "refund 1234",
+            ts: "2.2",
+            eventId: "Ev-malformed-refund",
+          }),
+          ack: sinon.stub(),
+        });
+
+        sinon.assert.notCalled(genericRefund);
+        expect(stubs.postMessage.firstCall.args[0].text).to.include("Usage:");
+      } finally {
+        config.redemptionAdmins.splice(
+          0,
+          config.redemptionAdmins.length,
+          ...originalAdmins,
+        );
+      }
+    });
+
+    it("does not send a Stadium resolution through the generic refund handler", async () => {
+      const originalAdmins = [...config.redemptionAdmins];
+      config.redemptionAdmins.splice(
+        0,
+        config.redemptionAdmins.length,
+        "Ucaller",
+      );
+      try {
+        const { app, stubs } = makeApp({
+          withRefund: true,
+          withStadium: true,
+        });
+        const genericRefund = sinon.stub(deduction, "refundDeduction");
+        sinon
+          .stub(stadium, "resolveRedemption")
+          .resolves({ status: "not_found" });
+
+        await app.processEvent({
+          body: eventBody({
+            channelType: "im",
+            channel: "Ddm",
+            text: "stadium resolve stadium:T1:V1 refund",
+            ts: "2.2",
+            eventId: "Ev-stadium-refund",
+          }),
+          ack: sinon.stub(),
+        });
+
+        expect(genericRefund.called).to.equal(false);
+        expect(stadium.resolveRedemption.calledOnce).to.equal(true);
+        expect(stubs.postMessage.callCount).to.equal(1);
+      } finally {
+        config.redemptionAdmins.splice(
+          0,
+          config.redemptionAdmins.length,
+          ...originalAdmins,
+        );
+      }
     });
   });
 

--- a/test/integration/service/deduction.js
+++ b/test/integration/service/deduction.js
@@ -5,6 +5,7 @@ let deduction;
 let recognitionCollection;
 let goldenRecognitionCollection;
 let deductionCollection;
+let deductionLockCollection;
 let client;
 
 describe("integration: service/deduction", function () {
@@ -15,6 +16,7 @@ describe("integration: service/deduction", function () {
     recognitionCollection = require("../../../database/recognitionCollection");
     goldenRecognitionCollection = require("../../../database/goldenRecognitionCollection");
     deductionCollection = require("../../../database/deductionCollection");
+    deductionLockCollection = require("../../../database/deductionLockCollection");
     client = require("../../../database/db");
     await client.connect();
   });
@@ -28,6 +30,7 @@ describe("integration: service/deduction", function () {
       recognitionCollection.deleteMany({}),
       goldenRecognitionCollection.deleteMany({}),
       deductionCollection.deleteMany({}),
+      deductionLockCollection.deleteMany({}),
     ]);
   });
 
@@ -114,6 +117,84 @@ describe("integration: service/deduction", function () {
 
       const record = await deductionCollection.findOne({ user: "Ureceiver" });
       expect(record.refund).to.equal(true);
+    });
+
+    it("reports only one of two concurrent refunds as newly refunded", async () => {
+      const insertedId = await deduction.createDeduction(
+        "Ureceiver",
+        5,
+        "test reason",
+      );
+
+      const results = await Promise.all([
+        deduction.refundDeduction(insertedId),
+        deduction.refundDeduction(insertedId),
+      ]);
+
+      expect(results.map((result) => result.status).sort()).to.deep.equal([
+        "already_refunded",
+        "refunded",
+      ]);
+    });
+
+    it("protects a string-id Stadium deduction from generic refund", async () => {
+      await deductionCollection.insertOne({
+        _id: "stadium:T1:V1",
+        source: "stadium",
+        status: "fulfilled",
+        user: "Ureceiver",
+        refund: false,
+        value: 5,
+      });
+
+      expect(
+        (await deduction.refundDeduction("stadium:T1:V1")).status,
+      ).to.equal("stadium");
+      expect(
+        (await deductionCollection.findOne({ _id: "stadium:T1:V1" })).refund,
+      ).to.equal(false);
+    });
+  });
+
+  describe("deduction locks", () => {
+    it("serializes a user and atomically reclaims an expired lease", async () => {
+      expect(
+        (await deduction.acquireLock("Ulocked", "first")).acquired,
+      ).to.equal(true);
+      expect(
+        (await deduction.acquireLock("Ulocked", "second")).acquired,
+      ).to.equal(false);
+
+      await deductionLockCollection.updateOne(
+        { _id: "Ulocked" },
+        { $set: { expiresAt: new Date(Date.now() - 1000) } },
+      );
+      expect(
+        (await deduction.acquireLock("Ulocked", "second")).acquired,
+      ).to.equal(true);
+      const record = await deductionLockCollection.findOne({ _id: "Ulocked" });
+      expect(record).to.include({
+        operationId: "second",
+        kind: "ephemeral",
+      });
+    });
+
+    it("blocks new deductions while Stadium work needs review", async () => {
+      await deductionCollection.insertOne({
+        _id: "stadium:T1:V1",
+        source: "stadium",
+        status: "needs_review",
+        user: "Ulocked",
+      });
+
+      expect(await deduction.acquireLock("Ulocked", "new")).to.deep.equal({
+        acquired: false,
+        reason: "stadium-review",
+        operationId: "stadium:T1:V1",
+      });
+      expect(
+        await deductionLockCollection.findOne({ _id: "Ulocked" }),
+      ).to.equal(null);
     });
   });
 });

--- a/test/integration/service/stadium.js
+++ b/test/integration/service/stadium.js
@@ -1,0 +1,298 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+let stadium;
+let deduction;
+let balance;
+let config;
+let client;
+let recognitionCollection;
+let deductionCollection;
+let deductionLockCollection;
+let originalConfig;
+
+function response(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+async function seedBalance(user, amount) {
+  await recognitionCollection.insertMany(
+    Array.from({ length: amount }, (_, index) => ({
+      recognizer: `Ugiver-${index}`,
+      recognizee: user,
+      timestamp: new Date(),
+      message: "integration balance",
+      channel: "C1",
+      values: [],
+    })),
+  );
+}
+
+describe("integration: service/stadium", function () {
+  this.timeout(30000);
+
+  before(async () => {
+    config = require("../../../config");
+    originalConfig = { ...config.stadium };
+    Object.assign(config.stadium, {
+      apiBaseUrl: "https://sandbox.example/api/v2",
+      clientId: "client",
+      clientSecret: "secret",
+      storeNumber: "store",
+      paymentMethod: "use_wallet_money",
+      billingCountry: "US",
+      billingZipcode: "60601",
+      fistbumpsPerUnit: 1,
+      pointsPerUnit: 1,
+      minimumFistbumps: 1,
+      maximumFistbumps: null,
+    });
+    stadium = require("../../../service/stadium");
+    deduction = require("../../../service/deduction");
+    balance = require("../../../service/balance");
+    recognitionCollection = require("../../../database/recognitionCollection");
+    deductionCollection = require("../../../database/deductionCollection");
+    deductionLockCollection = require("../../../database/deductionLockCollection");
+    client = require("../../../database/db");
+    await client.connect();
+  });
+
+  after(async () => {
+    Object.assign(config.stadium, originalConfig);
+    if (client) await client.close();
+  });
+
+  beforeEach(async () => {
+    stadium.resetTokenCache();
+    await Promise.all([
+      recognitionCollection.deleteMany({}),
+      deductionCollection.deleteMany({}),
+      deductionLockCollection.deleteMany({}),
+    ]);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("uses a deterministic id, reserves balance, and does not resend a duplicate", async () => {
+    await seedBalance("U1", 10);
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const first = await stadium.redeem({
+      user: "U1",
+      email: "USER@LIATRIO.COM",
+      fistbumps: 4,
+      redemptionId: "T1:V1",
+    });
+    expect(first).to.include({ status: "fulfilled", id: "stadium:T1:V1" });
+    const record = await deductionCollection.findOne({ _id: "stadium:T1:V1" });
+    expect(record).to.include({
+      source: "stadium",
+      status: "fulfilled",
+      corporateEmail: "user@liatrio.com",
+      value: 4,
+      refund: false,
+    });
+    expect(await balance.currentBalance("U1")).to.equal(6);
+    expect(await deductionLockCollection.findOne({ _id: "U1" })).to.equal(null);
+
+    const duplicate = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "T1:V1",
+    });
+    expect(duplicate.status).to.equal("duplicate");
+    expect(fetchStub.callCount).to.equal(2);
+  });
+
+  it("uses unresolved Stadium state as the review hold until admin resolution", async () => {
+    await seedBalance("U1", 10);
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub.onCall(1).resolves(response(500, {}));
+
+    const uncertain = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "T1:V2",
+    });
+    expect(uncertain.status).to.equal("needs_review");
+    expect(await deductionLockCollection.findOne({ _id: "U1" })).to.equal(null);
+    expect(await deduction.acquireLock("U1", "reward:new")).to.deep.equal({
+      acquired: false,
+      reason: "stadium-review",
+      operationId: "stadium:T1:V2",
+    });
+
+    const resolved = await stadium.resolveRedemption(
+      "stadium:T1:V2",
+      "refund",
+      "Uadmin",
+    );
+    expect(resolved.status).to.equal("refunded");
+    expect(await deductionLockCollection.findOne({ _id: "U1" })).to.equal(null);
+    expect(await balance.currentBalance("U1")).to.equal(10);
+    expect(
+      (await stadium.resolveRedemption("stadium:T1:V2", "refund", "Uadmin"))
+        .status,
+    ).to.equal("not_found");
+  });
+
+  it("claims review notifications once and retries failed delivery later", async () => {
+    await deductionCollection.insertOne({
+      _id: "stadium:notification",
+      source: "stadium",
+      status: "needs_review",
+      user: "U1",
+      value: 4,
+      refund: false,
+      timestamp: new Date(),
+      updatedAt: new Date(),
+    });
+    const now = new Date("2026-08-27T12:00:00.000Z");
+
+    const concurrent = await Promise.all([
+      stadium.claimReviewNotification("stadium:notification", now),
+      stadium.claimReviewNotification("stadium:notification", now),
+    ]);
+    const firstClaim = concurrent.find(Boolean);
+    expect(concurrent.filter(Boolean)).to.have.length(1);
+
+    await stadium.completeReviewNotification(
+      "stadium:notification",
+      firstClaim.claimId,
+      false,
+      now,
+    );
+    expect(
+      await stadium.claimReviewNotification(
+        "stadium:notification",
+        new Date(now.getTime() + 60 * 1000),
+      ),
+    ).to.equal(null);
+
+    const retry = await stadium.claimReviewNotification(
+      "stadium:notification",
+      new Date(now.getTime() + 16 * 60 * 1000),
+    );
+    expect(retry).not.to.equal(null);
+    await stadium.completeReviewNotification(
+      "stadium:notification",
+      retry.claimId,
+      true,
+      new Date(now.getTime() + 16 * 60 * 1000),
+    );
+    expect(
+      await stadium.claimReviewNotification(
+        "stadium:notification",
+        new Date(now.getTime() + 32 * 60 * 1000),
+      ),
+    ).to.equal(null);
+  });
+
+  it("reconciles only stale Stadium work and preserves unrelated live locks", async () => {
+    const old = new Date(Date.now() - deduction.LOCK_LEASE_MS - 1000);
+    const fresh = new Date();
+    await deductionCollection.insertMany([
+      {
+        _id: "stadium:reserved",
+        source: "stadium",
+        status: "reserved",
+        user: "U-reserved",
+        value: 2,
+        refund: false,
+        timestamp: old,
+        updatedAt: old,
+      },
+      {
+        _id: "stadium:sending",
+        source: "stadium",
+        status: "sending",
+        user: "U-sending",
+        value: 2,
+        refund: false,
+        timestamp: old,
+        updatedAt: old,
+      },
+      {
+        _id: "stadium:fresh",
+        source: "stadium",
+        status: "sending",
+        user: "U-fresh",
+        value: 2,
+        refund: false,
+        timestamp: fresh,
+        updatedAt: fresh,
+      },
+    ]);
+    await deductionLockCollection.insertMany([
+      {
+        _id: "U-reserved",
+        operationId: "stadium:reserved",
+        kind: "stadium-in-flight",
+        ownerId: "dead",
+        createdAt: old,
+        expiresAt: old,
+      },
+      {
+        _id: "U-sending",
+        operationId: "stadium:sending",
+        kind: "stadium-in-flight",
+        ownerId: "dead",
+        createdAt: old,
+        expiresAt: old,
+      },
+      {
+        _id: "U-fresh",
+        operationId: "stadium:fresh",
+        kind: "stadium-in-flight",
+        ownerId: "live",
+        createdAt: fresh,
+        expiresAt: new Date(fresh.getTime() + deduction.LOCK_LEASE_MS),
+      },
+      {
+        _id: "U-other",
+        operationId: "reward:active",
+        kind: "ephemeral",
+        ownerId: "other-instance",
+        createdAt: fresh,
+        expiresAt: new Date(fresh.getTime() + deduction.LOCK_LEASE_MS),
+      },
+      {
+        _id: "U-legacy",
+        operationId: "stadium:already-resolved",
+        kind: "stadium-review",
+        ownerId: null,
+        createdAt: old,
+      },
+    ]);
+
+    const result = await stadium.reconcilePending();
+    expect(result).to.deep.include({ refunded: 1, needsReview: 1 });
+    expect(
+      await deductionCollection.findOne({ _id: "stadium:reserved" }),
+    ).to.include({ status: "failed", refund: true });
+    expect(
+      await deductionCollection.findOne({ _id: "stadium:sending" }),
+    ).to.include({ status: "needs_review", refund: false });
+    expect(
+      await deductionCollection.findOne({ _id: "stadium:fresh" }),
+    ).to.include({ status: "sending" });
+    expect(
+      await deductionLockCollection.findOne({ _id: "U-other" }),
+    ).to.include({ operationId: "reward:active" });
+    expect(
+      await deductionLockCollection.findOne({ _id: "U-fresh" }),
+    ).to.include({ operationId: "stadium:fresh" });
+    expect(await deductionLockCollection.findOne({ _id: "U-legacy" })).to.equal(
+      null,
+    );
+  });
+});

--- a/test/service/deduction.js
+++ b/test/service/deduction.js
@@ -4,6 +4,7 @@ const expect = require("chai").expect;
 
 const deduction = require("../../service/deduction");
 const deductionCollection = require("../../database/deductionCollection");
+const deductionLockCollection = require("../../database/deductionLockCollection");
 
 const balance = require("../../service/balance");
 
@@ -54,12 +55,63 @@ describe("deduction/balance", () => {
     it("should call refund deduction", async () => {
       const findOneAndUpdate = sinon
         .stub(deductionCollection, "findOneAndUpdate")
-        .resolves({});
+        .resolves({ refund: false });
 
-      await deduction.refundDeduction("62171d78b5daaa0011771cfd");
-      sinon.assert.calledWith(findOneAndUpdate, {
-        _id: new ObjectId("62171d78b5daaa0011771cfd"),
-      });
+      const result = await deduction.refundDeduction(
+        "62171d78b5daaa0011771cfd",
+      );
+      expect(result.status).to.equal("refunded");
+      sinon.assert.calledWith(
+        findOneAndUpdate,
+        {
+          _id: new ObjectId("62171d78b5daaa0011771cfd"),
+          source: { $ne: "stadium" },
+          refund: false,
+        },
+        { $set: { refund: true } },
+      );
+    });
+
+    it("should reject invalid, missing, refunded, and Stadium deductions", async () => {
+      expect((await deduction.refundDeduction("bad-id")).status).to.equal(
+        "not_found",
+      );
+      sinon.stub(deductionCollection, "findOneAndUpdate").resolves(null);
+      const find = sinon.stub(deductionCollection, "findOne");
+      find.onCall(0).resolves(null);
+      find.onCall(1).resolves({ refund: true });
+      find.onCall(2).resolves({ source: "stadium", refund: false });
+      const id = "62171d78b5daaa0011771cfd";
+      expect((await deduction.refundDeduction(id)).status).to.equal(
+        "not_found",
+      );
+      expect((await deduction.refundDeduction(id)).status).to.equal(
+        "already_refunded",
+      );
+      expect((await deduction.refundDeduction(id)).status).to.equal("stadium");
+    });
+
+    it("should protect string-id Stadium deductions from generic refunds", async () => {
+      const update = sinon
+        .stub(deductionCollection, "findOneAndUpdate")
+        .resolves(null);
+      const find = sinon
+        .stub(deductionCollection, "findOne")
+        .resolves({ source: "stadium", refund: false });
+
+      expect(
+        (await deduction.refundDeduction("stadium:T1:V1")).status,
+      ).to.equal("stadium");
+      sinon.assert.calledWith(
+        update,
+        {
+          _id: "stadium:T1:V1",
+          source: { $ne: "stadium" },
+          refund: false,
+        },
+        { $set: { refund: true } },
+      );
+      sinon.assert.calledWith(find, { _id: "stadium:T1:V1" });
     });
   });
 
@@ -76,6 +128,83 @@ describe("deduction/balance", () => {
 
       const result = await deduction.isBalanceSufficient("testUser", 30);
       expect(result).to.be.false;
+    });
+  });
+
+  describe("deduction locks", () => {
+    beforeEach(() => {
+      sinon.stub(deductionCollection, "findOne").resolves(null);
+    });
+
+    it("acquires and releases a lock for an operation", async () => {
+      const insert = sinon
+        .stub(deductionLockCollection, "insertOne")
+        .resolves({ acknowledged: true });
+      const remove = sinon
+        .stub(deductionLockCollection, "deleteOne")
+        .resolves({ deletedCount: 1 });
+      expect(await deduction.acquireLock("U1", "operation")).to.deep.equal({
+        acquired: true,
+      });
+      await deduction.releaseLock("U1", "operation");
+      expect(insert.firstCall.args[0]).to.include({
+        _id: "U1",
+        operationId: "operation",
+        kind: "ephemeral",
+      });
+      expect(insert.firstCall.args[0].expiresAt).to.be.instanceOf(Date);
+      sinon.assert.calledWith(
+        remove,
+        sinon.match({ _id: "U1", operationId: "operation" }),
+      );
+    });
+
+    it("returns details for an existing user lock", async () => {
+      sinon
+        .stub(deductionLockCollection, "insertOne")
+        .rejects(Object.assign(new Error("duplicate"), { code: 11000 }));
+      sinon.stub(deductionLockCollection, "findOneAndUpdate").resolves(null);
+      sinon.stub(deductionLockCollection, "findOne").resolves({
+        operationId: "existing",
+        kind: "ephemeral",
+      });
+      expect(await deduction.acquireLock("U1", "operation")).to.deep.equal({
+        acquired: false,
+        reason: "in-progress",
+        operationId: "existing",
+      });
+    });
+
+    it("atomically replaces an expired lock", async () => {
+      sinon
+        .stub(deductionLockCollection, "insertOne")
+        .rejects(Object.assign(new Error("duplicate"), { code: 11000 }));
+      const replace = sinon
+        .stub(deductionLockCollection, "findOneAndUpdate")
+        .resolves({ operationId: "old" });
+      expect(await deduction.acquireLock("U1", "new")).to.deep.equal({
+        acquired: true,
+      });
+      expect(replace.firstCall.args[0]).to.have.nested.property(
+        "expiresAt.$lte",
+      );
+      expect(replace.firstCall.args[1].$set).to.include({
+        operationId: "new",
+        kind: "ephemeral",
+      });
+      expect(replace.firstCall.args[1].$set).not.to.have.property("_id");
+    });
+
+    it("uses a needs-review deduction as the authoritative hold", async () => {
+      deductionCollection.findOne.resolves({ _id: "stadium:T1:V1" });
+      const insert = sinon.stub(deductionLockCollection, "insertOne");
+
+      expect(await deduction.acquireLock("U1", "new")).to.deep.equal({
+        acquired: false,
+        reason: "stadium-review",
+        operationId: "stadium:T1:V1",
+      });
+      sinon.assert.notCalled(insert);
     });
   });
 

--- a/test/service/redeem.js
+++ b/test/service/redeem.js
@@ -1,6 +1,7 @@
 const sinon = require("sinon");
 const expect = require("chai").expect;
 const redeem = require("../../service/redeem");
+const config = require("../../config");
 const rewardCollection = require("../../database/rewardCollection");
 
 function stubFindSortToArray(results) {
@@ -115,6 +116,20 @@ describe("service/redeem", () => {
       const selector = blocks[blocks.length - 1];
       const optionNames = selector.accessory.options.map((o) => o.text.text);
       expect(optionNames).to.deep.equal(["Alpha", "Bravo", "Charlie"]);
+    });
+
+    it("adds Stadium as a separate enabled reward category", () => {
+      const original = config.stadium.enabled;
+      config.stadium.enabled = true;
+      try {
+        const blocks = redeem.buildRedeemBlocks([], 10);
+        const stadiumBlock = blocks.find(
+          (block) => block.accessory?.action_id === "stadium_redeem_open",
+        );
+        expect(stadiumBlock.text.text).to.include("Stadium points");
+      } finally {
+        config.stadium.enabled = original;
+      }
     });
   });
 

--- a/test/service/refund.js
+++ b/test/service/refund.js
@@ -12,7 +12,7 @@ describe("service/refund", () => {
       const testMessage = {
         user: "testAdmin",
         channel: "testchannel",
-        text: "gratibot refund deductionid",
+        text: "gratibot refund 62171d78b5daaa0011771cfd",
       };
       const testClient = {
         chat: {
@@ -25,13 +25,78 @@ describe("service/refund", () => {
         client: testClient,
         admins: testAdmins,
       };
-      sinon.stub(deduction, "refundDeduction").resolves({});
+      sinon.stub(deduction, "refundDeduction").resolves({ status: "refunded" });
       await refund.respondToRefund(testObject);
       sinon.assert.calledWith(testClient.chat.postMessage, {
         channel: testMessage.channel,
         user: testMessage.user,
         text: "Refund successfully given",
       });
+    });
+
+    it("should accept a deduction id copied with backticks", async () => {
+      const client = { chat: { postMessage: sinon.stub() } };
+      const refundStub = sinon
+        .stub(deduction, "refundDeduction")
+        .resolves({ status: "refunded" });
+
+      await refund.respondToRefund({
+        message: {
+          user: "testAdmin",
+          channel: "testchannel",
+          text: "refund `62171d78b5daaa0011771cfd`",
+        },
+        client,
+        admins: ["testAdmin"],
+      });
+
+      sinon.assert.calledWith(refundStub, "62171d78b5daaa0011771cfd");
+    });
+
+    it("should direct Stadium deductions to the resolution command", async () => {
+      const client = { chat: { postMessage: sinon.stub() } };
+      const refundStub = sinon
+        .stub(deduction, "refundDeduction")
+        .resolves({ status: "stadium" });
+
+      await refund.respondToRefund({
+        message: {
+          user: "testAdmin",
+          channel: "testchannel",
+          text: "refund stadium:T1:V1",
+        },
+        client,
+        admins: ["testAdmin"],
+      });
+
+      sinon.assert.calledWith(refundStub, "stadium:T1:V1");
+      sinon.assert.calledWith(
+        client.chat.postMessage,
+        sinon.match({
+          text: sinon.match("stadium resolve <id> refund"),
+        }),
+      );
+    });
+
+    it("should reject a malformed refund command", async () => {
+      const client = { chat: { postMessage: sinon.stub() } };
+      const refundStub = sinon.stub(deduction, "refundDeduction");
+      await refund.respondToRefund({
+        message: {
+          user: "testAdmin",
+          channel: "testchannel",
+          text: "stadium resolve stadium:T:V refund",
+        },
+        client,
+        admins: ["testAdmin"],
+      });
+      sinon.assert.notCalled(refundStub);
+      sinon.assert.calledWith(
+        client.chat.postMessage,
+        sinon.match({
+          text: "Usage: `refund <deduction-id>`",
+        }),
+      );
     });
 
     it("should return a message informing user that they must be redemption admin", async () => {

--- a/test/service/stadium.js
+++ b/test/service/stadium.js
@@ -1,0 +1,570 @@
+const sinon = require("sinon");
+const expect = require("chai").expect;
+
+const config = require("../../config");
+const stadium = require("../../service/stadium");
+const balance = require("../../service/balance");
+const deduction = require("../../service/deduction");
+const deductionCollection = require("../../database/deductionCollection");
+
+function response(status, body) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+describe("service/stadium", () => {
+  let originalConfig;
+
+  beforeEach(() => {
+    originalConfig = { ...config.stadium };
+    Object.assign(config.stadium, {
+      apiBaseUrl: "https://sandbox.example/api/v2",
+      clientId: "client",
+      clientSecret: "secret",
+      storeNumber: "store-1",
+      paymentMethod: "use_wallet_money",
+      billingCountry: "US",
+      billingZipcode: "60601",
+      fistbumpsPerUnit: 2,
+      pointsPerUnit: 5,
+      minimumFistbumps: 2,
+      maximumFistbumps: 20,
+    });
+    stadium.resetTokenCache();
+  });
+
+  afterEach(() => {
+    Object.assign(config.stadium, originalConfig);
+    stadium.resetTokenCache();
+    sinon.restore();
+  });
+
+  it("normalizes only exact Liatrio corporate emails", () => {
+    expect(stadium.normalizeCorporateEmail(" Person@Liatrio.com ")).to.equal(
+      "person@liatrio.com",
+    );
+    expect(() =>
+      stadium.normalizeCorporateEmail("person@evil-liatrio.com"),
+    ).to.throw(stadium.StadiumError);
+    expect(() => stadium.normalizeCorporateEmail("missing-at-sign")).to.throw(
+      stadium.StadiumError,
+    );
+    try {
+      stadium.normalizeCorporateEmail("contractor@example.com");
+    } catch (error) {
+      expect(error.userMessage).to.include("liatrio.com email");
+    }
+  });
+
+  it("converts configured whole conversion units and rejects invalid amounts", () => {
+    expect(stadium.fistbumpsToPoints(4)).to.equal(10);
+    for (const value of [1, 3, 21, 1.5, NaN]) {
+      expect(() => stadium.fistbumpsToPoints(value)).to.throw(
+        stadium.StadiumError,
+      );
+    }
+  });
+
+  it("reports invalid conversion limits as configuration errors", () => {
+    for (const maximum of [0, NaN, 1.5]) {
+      config.stadium.maximumFistbumps = maximum;
+      try {
+        stadium.fistbumpsToPoints(4);
+        expect.fail("expected invalid configuration to throw");
+      } catch (error) {
+        expect(error).to.be.instanceOf(stadium.StadiumError);
+        expect(error.message).to.equal(
+          "Invalid Stadium conversion configuration.",
+        );
+        expect(error.userMessage).to.include("conversion settings are invalid");
+      }
+    }
+
+    config.stadium.maximumFistbumps = 20;
+    config.stadium.minimumFistbumps = 1;
+    expect(() => stadium.fistbumpsToPoints(4)).to.throw(
+      stadium.StadiumError,
+      "Invalid Stadium conversion configuration.",
+    );
+  });
+
+  it("explains when an amount is not a complete conversion unit", () => {
+    expect(() => stadium.fistbumpsToPoints(3)).to.throw(
+      stadium.StadiumError,
+      "in multiples of 2",
+    );
+  });
+
+  it("rejects an undocumented payment method before authenticating", async () => {
+    config.stadium.paymentMethod = "credit_card";
+    const fetchStub = sinon.stub(global, "fetch");
+    await expect(stadium.getAccessToken()).to.be.rejectedWith(
+      stadium.StadiumError,
+      "Invalid Stadium payment method",
+    );
+    expect(fetchStub.called).to.equal(false);
+  });
+
+  it("builds a whole-number modal capped by current balance", () => {
+    const modal = stadium.buildRedemptionModal(12);
+    expect(modal.callback_id).to.equal("stadium_redeem_submit");
+    const input = modal.blocks[1].element;
+    expect(input.type).to.equal("number_input");
+    expect(input.is_decimal_allowed).to.equal(false);
+    expect(input.min_value).to.equal("2");
+    expect(input.max_value).to.equal("12");
+  });
+
+  it("builds an immediately-openable modal without querying a balance", () => {
+    config.stadium.maximumFistbumps = null;
+    const modal = stadium.buildRedemptionModal();
+    expect(modal.blocks[0].text.text).to.include(
+      "balance will be checked when you submit",
+    );
+    expect(modal.blocks[1].element).not.to.have.property("max_value");
+  });
+
+  it("authenticates, caches the token, and sends the expected points payload", async () => {
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub
+      .onCall(0)
+      .resolves(response(200, { token: "token", expires_in: 3600 }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER-1", payment_state: "paid" }));
+    fetchStub
+      .onCall(2)
+      .resolves(response(200, { number: "ORDER-2", payment_state: "paid" }));
+
+    const first = await stadium.sendPoints({
+      email: "person@liatrio.com",
+      points: 10,
+      redemptionId: "stadium:T:V",
+    });
+    await stadium.sendPoints({
+      email: "person@liatrio.com",
+      points: 5,
+      redemptionId: "stadium:T:V2",
+    });
+
+    expect(first.orderNumber).to.equal("ORDER-1");
+    expect(fetchStub.callCount).to.equal(3);
+    const request = JSON.parse(fetchStub.secondCall.args[1].body);
+    expect(request).to.include({
+      contact_emails: "person@liatrio.com",
+      organizer_share: 10,
+      auto_accept_points: true,
+      send_shop_points: true,
+    });
+    expect(request.payment_method).to.deep.equal(["use_wallet_money"]);
+    expect(fetchStub.secondCall.args[1].headers.authorization).to.equal(
+      "Bearer token",
+    );
+  });
+
+  it("classifies client rejection as definite and server/malformed results as ambiguous", async () => {
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "one" }));
+    fetchStub.onCall(1).resolves(response(422, { error: "invalid" }));
+    await expect(
+      stadium.sendPoints({ email: "x", points: 1, redemptionId: "one" }),
+    ).to.be.rejected.then((error) =>
+      expect(error.classification).to.equal("definite"),
+    );
+
+    stadium.resetTokenCache();
+    fetchStub.onCall(2).resolves(response(200, { token: "two" }));
+    fetchStub.onCall(3).resolves(response(500, {}));
+    await expect(
+      stadium.sendPoints({ email: "x", points: 1, redemptionId: "two" }),
+    ).to.be.rejected.then((error) =>
+      expect(error.classification).to.equal("ambiguous"),
+    );
+
+    stadium.resetTokenCache();
+    fetchStub.onCall(4).resolves(response(200, { token: "three" }));
+    fetchStub
+      .onCall(5)
+      .resolves(response(200, { number: "ORDER", payment_state: "pending" }));
+    await expect(
+      stadium.sendPoints({ email: "x", points: 1, redemptionId: "three" }),
+    ).to.be.rejected.then((error) =>
+      expect(error.classification).to.equal("ambiguous"),
+    );
+  });
+
+  it("evicts a cached token after Stadium returns 401", async () => {
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "revoked" }));
+    fetchStub.onCall(1).resolves(response(401, { error: "invalid token" }));
+    await expect(
+      stadium.sendPoints({ email: "x", points: 1, redemptionId: "one" }),
+    ).to.be.rejectedWith(stadium.StadiumError);
+
+    fetchStub.onCall(2).resolves(response(200, { token: "replacement" }));
+    fetchStub
+      .onCall(3)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+    await stadium.sendPoints({ email: "x", points: 1, redemptionId: "two" });
+    expect(fetchStub.getCall(2).args[0]).to.include("/oauth/token");
+    expect(fetchStub.getCall(3).args[1].headers.authorization).to.equal(
+      "Bearer replacement",
+    );
+  });
+
+  it("fulfills a redemption and releases its balance lock", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    sinon.stub(deductionCollection, "updateOne").resolves({ modifiedCount: 1 });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const result = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "T:V",
+    });
+    expect(result).to.include({ status: "fulfilled", stadiumPoints: 10 });
+    expect(deduction.releaseLock.calledWith("U1", "stadium:T:V")).to.equal(
+      true,
+    );
+  });
+
+  it("refunds a definite rejection and marks an ambiguous result for review", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    const update = sinon
+      .stub(deductionCollection, "updateOne")
+      .resolves({ modifiedCount: 1 });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "one" }));
+    fetchStub.onCall(1).resolves(response(422, {}));
+    expect(
+      (
+        await stadium.redeem({
+          user: "U1",
+          email: "user@liatrio.com",
+          fistbumps: 4,
+          redemptionId: "definite",
+        })
+      ).status,
+    ).to.equal("failed");
+    expect(
+      update.getCalls().some((call) => call.args[1].$set?.refund === true),
+    ).to.equal(true);
+
+    stadium.resetTokenCache();
+    fetchStub.onCall(2).resolves(response(200, { token: "two" }));
+    fetchStub.onCall(3).resolves(response(500, {}));
+    expect(
+      (
+        await stadium.redeem({
+          user: "U2",
+          email: "user@liatrio.com",
+          fistbumps: 4,
+          redemptionId: "ambiguous",
+        })
+      ).status,
+    ).to.equal("needs_review");
+    expect(
+      update
+        .getCalls()
+        .some((call) => call.args[1].$set?.status === "needs_review"),
+    ).to.equal(true);
+    expect(
+      update
+        .getCalls()
+        .some(
+          (call) =>
+            call.args[1].$set?.reviewNotification?.nextAttemptAt instanceof
+            Date,
+        ),
+    ).to.equal(true);
+    expect(
+      deduction.releaseLock.calledWith("U2", "stadium:ambiguous"),
+    ).to.equal(true);
+  });
+
+  it("CAS-guards an ambiguous transition and omits missing error details", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    const update = sinon.stub(deductionCollection, "updateOne");
+    update.onCall(0).resolves({ modifiedCount: 1 });
+    update.onCall(1).rejects(new Error("database response lost"));
+    update.onCall(2).resolves({ modifiedCount: 1 });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const result = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "cas",
+    });
+
+    expect(result.status).to.equal("needs_review");
+    expect(update.thirdCall.args[0]).to.deep.equal({
+      _id: "stadium:cas",
+      status: { $in: ["sending"] },
+    });
+    expect(update.thirdCall.args[1].$set).not.to.have.property("stadium");
+  });
+
+  it("does not overwrite a terminal state after a delayed request resumes", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    const update = sinon.stub(deductionCollection, "updateOne");
+    update.onCall(0).resolves({ modifiedCount: 1 });
+    update.onCall(1).rejects(new Error("database response lost"));
+    update.onCall(2).resolves({ modifiedCount: 0 });
+    sinon.stub(deductionCollection, "findOne").resolves({
+      _id: "stadium:terminal",
+      status: "refunded",
+      refund: true,
+    });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const result = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "terminal",
+    });
+
+    expect(result.status).to.equal("failed");
+    expect(update.thirdCall.args[0]).to.have.nested.property("status.$in");
+  });
+
+  it("records a paid response that arrives after reconciliation", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    const update = sinon.stub(deductionCollection, "updateOne");
+    update.onCall(0).resolves({ modifiedCount: 1 });
+    update.onCall(1).resolves({ modifiedCount: 0 });
+    update.onCall(2).resolves({ modifiedCount: 1 });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const result = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "late",
+    });
+
+    expect(result).to.include({
+      status: "fulfilled",
+      stadiumPoints: 10,
+      orderNumber: "ORDER",
+    });
+    expect(update.thirdCall.args[0]).to.deep.equal({
+      _id: "stadium:late",
+      status: "needs_review",
+    });
+    expect(update.thirdCall.args[1].$set).to.deep.include({
+      status: "fulfilled",
+      stadium: { orderNumber: "ORDER", paymentState: "paid" },
+    });
+  });
+
+  it("reports a late paid response that conflicts with an admin refund", async () => {
+    sinon.stub(deduction, "acquireLock").resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(10);
+    sinon.stub(deductionCollection, "insertOne").resolves({});
+    const update = sinon.stub(deductionCollection, "updateOne");
+    update.onCall(0).resolves({ modifiedCount: 1 });
+    update.onCall(1).resolves({ modifiedCount: 0 });
+    update.onCall(2).resolves({ modifiedCount: 0 });
+    sinon.stub(deductionCollection, "findOne").resolves({
+      _id: "stadium:conflict",
+      status: "refunded",
+      refund: true,
+    });
+    const fetchStub = sinon.stub(global, "fetch");
+    fetchStub.onCall(0).resolves(response(200, { token: "token" }));
+    fetchStub
+      .onCall(1)
+      .resolves(response(200, { number: "ORDER", payment_state: "paid" }));
+
+    const result = await stadium.redeem({
+      user: "U1",
+      email: "user@liatrio.com",
+      fistbumps: 4,
+      redemptionId: "conflict",
+    });
+
+    expect(result).to.include({
+      status: "resolution_conflict",
+      terminalStatus: "refunded",
+      orderNumber: "ORDER",
+    });
+  });
+
+  it("returns busy or insufficient without dispatching points", async () => {
+    sinon
+      .stub(deduction, "acquireLock")
+      .onCall(0)
+      .resolves({
+        acquired: false,
+        reason: "stadium-review",
+        operationId: "stadium:old",
+      })
+      .onCall(1)
+      .resolves({ acquired: true });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon.stub(balance, "currentBalance").resolves(1);
+    expect(
+      await stadium.redeem({
+        user: "U",
+        email: "u@liatrio.com",
+        fistbumps: 2,
+        redemptionId: "1",
+      }),
+    ).to.deep.include({
+      status: "busy",
+      reason: "stadium-review",
+      operationId: "stadium:old",
+    });
+    expect(
+      (
+        await stadium.redeem({
+          user: "U",
+          email: "u@liatrio.com",
+          fistbumps: 2,
+          redemptionId: "2",
+        })
+      ).status,
+    ).to.equal("insufficient");
+  });
+
+  it("resolves an uncertain redemption and releases the held lock", async () => {
+    sinon.stub(deductionCollection, "findOne").resolves({
+      _id: "stadium:T:V",
+      user: "U1",
+    });
+    sinon.stub(deductionCollection, "updateOne").resolves({ modifiedCount: 1 });
+    sinon.stub(deduction, "releaseLock").resolves();
+    const result = await stadium.resolveRedemption(
+      "stadium:T:V",
+      "refund",
+      "Uadmin",
+    );
+    expect(result.status).to.equal("refunded");
+    expect(deduction.releaseLock.calledWith("U1", "stadium:T:V")).to.equal(
+      true,
+    );
+  });
+
+  it("claims and completes durable review notifications", async () => {
+    const now = new Date("2026-08-27T12:00:00.000Z");
+    const findAndUpdate = sinon
+      .stub(deductionCollection, "findOneAndUpdate")
+      .resolves({ _id: "stadium:T:V", user: "U1" });
+    const update = sinon
+      .stub(deductionCollection, "updateOne")
+      .resolves({ modifiedCount: 1 });
+
+    const claim = await stadium.claimReviewNotification("stadium:T:V", now);
+    expect(claim.record).to.include({ _id: "stadium:T:V", user: "U1" });
+    expect(claim.claimId).to.be.a("string");
+    expect(findAndUpdate.firstCall.args[0]).to.deep.include({
+      _id: "stadium:T:V",
+      source: "stadium",
+      status: "needs_review",
+    });
+    expect(findAndUpdate.firstCall.args[2]).to.deep.equal({
+      returnDocument: "after",
+    });
+
+    await stadium.completeReviewNotification(
+      "stadium:T:V",
+      claim.claimId,
+      false,
+      now,
+    );
+    expect(
+      update.firstCall.args[1].$set["reviewNotification.nextAttemptAt"],
+    ).to.be.greaterThan(now);
+
+    await stadium.completeReviewNotification(
+      "stadium:T:V",
+      claim.claimId,
+      true,
+      now,
+    );
+    expect(
+      update.secondCall.args[1].$set["reviewNotification.notifiedAt"],
+    ).to.equal(now);
+  });
+
+  it("reconciles reserved and sending redemptions after startup", async () => {
+    const old = new Date(Date.now() - deduction.LOCK_LEASE_MS - 1000);
+    const cursors = [
+      {
+        toArray: sinon
+          .stub()
+          .resolves([{ _id: "r", user: "U1", updatedAt: old }]),
+      },
+      {
+        toArray: sinon
+          .stub()
+          .resolves([{ _id: "s", user: "U2", updatedAt: old }]),
+      },
+    ];
+    sinon
+      .stub(deductionCollection, "find")
+      .onCall(0)
+      .returns(cursors[0])
+      .onCall(1)
+      .returns(cursors[1]);
+    sinon.stub(deductionCollection, "updateOne").resolves({ modifiedCount: 1 });
+    sinon.stub(deduction, "releaseLock").resolves();
+    sinon
+      .stub(deduction, "cleanupLegacyReviewLocks")
+      .resolves({ deletedCount: 0 });
+    sinon.stub(deduction, "cleanupExpiredLocks").resolves({ deletedCount: 0 });
+    const result = await stadium.reconcilePending();
+    expect(result).to.deep.include({
+      refunded: 1,
+      needsReview: 1,
+    });
+    expect(result.refundedRecords[0]._id).to.equal("r");
+    expect(result.needsReviewRecords[0]._id).to.equal("s");
+    expect(
+      deductionCollection.updateOne
+        .getCalls()
+        .some(
+          (call) =>
+            call.args[1].$set?.reviewNotification?.nextAttemptAt instanceof
+            Date,
+        ),
+    ).to.equal(true);
+    sinon.assert.calledWith(deduction.releaseLock, "U2", "s", {
+      force: true,
+    });
+  });
+});

--- a/test/service/stadium.js
+++ b/test/service/stadium.js
@@ -24,6 +24,7 @@ describe("service/stadium", () => {
       paymentMethod: "use_wallet_money",
       billingCountry: "US",
       billingZipcode: "60601",
+      emailSource: "modal",
       fistbumpsPerUnit: 2,
       pointsPerUnit: 5,
       minimumFistbumps: 2,
@@ -51,8 +52,17 @@ describe("service/stadium", () => {
     try {
       stadium.normalizeCorporateEmail("contractor@example.com");
     } catch (error) {
-      expect(error.userMessage).to.include("liatrio.com email");
+      expect(error.userMessage).to.include("@liatrio.com email");
     }
+  });
+
+  it("accepts only the documented email sources", () => {
+    expect(stadium.validateEmailSource("modal")).to.equal("modal");
+    expect(stadium.validateEmailSource("slack")).to.equal("slack");
+    expect(() => stadium.validateEmailSource("fallback")).to.throw(
+      stadium.StadiumError,
+      "Invalid Stadium email source.",
+    );
   });
 
   it("converts configured whole conversion units and rejects invalid amounts", () => {
@@ -107,7 +117,16 @@ describe("service/stadium", () => {
   it("builds a whole-number modal capped by current balance", () => {
     const modal = stadium.buildRedemptionModal(12);
     expect(modal.callback_id).to.equal("stadium_redeem_submit");
-    const input = modal.blocks[1].element;
+    expect(JSON.parse(modal.private_metadata)).to.deep.equal({
+      emailSource: "modal",
+    });
+    const email = modal.blocks.find(
+      (block) => block.block_id === "stadium_email",
+    );
+    expect(email.element.type).to.equal("email_text_input");
+    const input = modal.blocks.find(
+      (block) => block.block_id === "stadium_amount",
+    ).element;
     expect(input.type).to.equal("number_input");
     expect(input.is_decimal_allowed).to.equal(false);
     expect(input.min_value).to.equal("2");
@@ -120,7 +139,21 @@ describe("service/stadium", () => {
     expect(modal.blocks[0].text.text).to.include(
       "balance will be checked when you submit",
     );
-    expect(modal.blocks[1].element).not.to.have.property("max_value");
+    const input = modal.blocks.find(
+      (block) => block.block_id === "stadium_amount",
+    ).element;
+    expect(input).not.to.have.property("max_value");
+  });
+
+  it("omits the email field when Slack supplies the address", () => {
+    config.stadium.emailSource = "slack";
+    const modal = stadium.buildRedemptionModal();
+    expect(JSON.parse(modal.private_metadata)).to.deep.equal({
+      emailSource: "slack",
+    });
+    expect(
+      modal.blocks.some((block) => block.block_id === "stadium_email"),
+    ).to.equal(false);
   });
 
   it("authenticates, caches the token, and sends the expected points payload", async () => {


### PR DESCRIPTION
## Why?

Liatrio retired the Axomo store in favor of Stadium. Gratibot therefore needs to transform earned fistbumps into Stadium point gifts that employees can redeem and spend in the Stadium store.

This removes the routine operator overhead required by the old store workflow. Manual intervention is limited to rare cases where Stadium's response is uncertain and Gratibot cannot safely determine whether points were issued.

## What?

- Adds Stadium as a dedicated redemption option, with configurable fistbump-to-point ratios and minimum/maximum redemption amounts.
- Validates and normalizes the recipient's `@liatrio.com` email and echoes the email, fistbumps, Stadium points, and order number in the success confirmation.
- Uses a required modal email field by default so production does not depend on the currently unavailable `users:read.email` permission.
- Preserves Slack-profile email lookup behind configuration for environments where `users:read.email` can be installed.
- Authenticates with Stadium, creates point-gift orders, and accepts fulfillment only when Stadium returns an order number with a paid payment state.
- Records Stadium redemptions through durable reserved, sending, fulfilled, failed, needs-review, and refunded states.
- Automatically restores fistbumps for definite failures while holding uncertain outcomes for admin review instead of risking duplicate point issuance.
- Adds per-user deduction locks so concurrent Stadium and ordinary reward redemptions cannot overspend a balance.
- Adds admin review and resolution commands, durable review notifications, and startup/periodic reconciliation for interrupted redemptions.
- Prevents additional deductions while a Stadium redemption is awaiting review.
- Adds environment and Terraform wiring, using versionless Azure Key Vault references for Stadium credentials so secret values do not enter Terraform state.
- Enables the preprod-backed integration in nonprod while leaving production disabled until its store and billing settings are supplied.
- Documents the configuration, data model, operational workflow, and sandbox verification process.
- Adds unit and integration coverage across Slack interactions, conversion and email validation, API outcomes, locking, reconciliation, refunds, and admin resolution.

## Verification

- `npm test` under Node.js 24 — 329 passing
- `npm run lint`
- Slack Block Kit validation for the rewards message and Stadium modal
- Local Slack CLI testing of:
  - invalid email and conversion amounts
  - successful manual-email and Slack-profile-email redemptions
  - insufficient balances
  - definite 4xx failures and automatic refunds
  - 401 token eviction and reauthentication
  - ambiguous 5xx outcomes, review locking, admin listing, and refund resolution
  - stale modals in both email-source directions
  - invalid configuration and disabled stale-button behavior
- Stadium preprod orders:
  - `R792746116` — 1 fistbump to 1 point, manual email
  - `R352533155` — 2 fistbumps to 3 points, manual email
  - `R106196013` — 1 fistbump to 1 point, Slack profile email

All three preprod orders were confirmed in the Stadium dashboard for `austinw@liatrio.com`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Stadium reward redemptions through Slack, with configurable email entry and automatic Slack email lookup.
  - Added admin review and resolution workflows for uncertain Stadium redemptions.
  - Added automatic reconciliation to recover interrupted redemptions and notify reviewers.

- **Bug Fixes**
  - Improved refund handling with validation, clearer status messages, and protection for Stadium redemptions.
  - Prevented overlapping deductions or redemptions for the same person, with informative messages when an operation is already in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->