### PR TITLE
fix(deps): pin mongodb driver to 7.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^5.0.0",
         "lodash": "^4.18.1",
         "moment-timezone": "^0.6.0",
-        "mongodb": "^7.0.0",
+        "mongodb": "7.5.0",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -5380,9 +5380,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.6.0.tgz",
-      "integrity": "sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+      "integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.4.11",
         "bson": "^7.2.0",
@@ -14081,9 +14081,9 @@
       }
     },
     "mongodb": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.6.0.tgz",
-      "integrity": "sha512-WbZ6OCjYw2c53LOjfkQa+reXr7kIiOVpXXglnASFuiMtif0BvsMwHe3ClJHLm1/r7wJFwaasfFtD6iYIktB01g==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.5.0.tgz",
+      "integrity": "sha512-5FnrEDLnvp6ycUOGLNLLU33BfCx2qmp2mJjGPDwKLruYsVzXVSK5fsGpoDXvsXJwBfBsD7ebMRdawbDxC2814g==",
       "requires": {
         "@mongodb-js/saslprep": "^1.4.11",
         "bson": "^7.2.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "express": "^5.0.0",
     "lodash": "^4.18.1",
     "moment-timezone": "^0.6.0",
-    "mongodb": "^7.0.0",
+    "mongodb": "7.5.0",
     "winston": "^3.17.0"
   },
   "devDependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,14 @@
       "automerge": true,
       "autoApprove": true,
       "groupName": "Dependencies (non-major)"
+    },
+    {
+      "description": [
+        "Keep the MongoDB driver compatible with Cosmos Mongo API 4.2 until Cosmos is upgraded to 5.0 or newer"
+      ],
+      "matchPackageNames": ["mongodb"],
+      "allowedVersions": "<7.6.0",
+      "rangeStrategy": "pin"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- pin the MongoDB Node driver to exactly 7.5.0
- prevent Renovate from selecting 7.6.0 or newer until Cosmos DB is upgraded from Mongo API 4.2

## Why

MongoDB Node driver 7.6.0 raised its minimum supported MongoDB server version to 4.4 (wire version 9). The nonprod Cosmos DB account exposes Mongo API 4.2 (wire version 8), so the application cannot connect and enters a restart loop. Driver 7.5.0 retains compatibility with the current Cosmos API.

## Validation

- clean install under Node.js 24
- `npm test` — 329 unit tests and 30 integration tests pass; coverage checks pass
- `npm run lint`
- `npm ls mongodb --depth=0` — resolves `mongodb@7.5.0`

No application or infrastructure code is changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version management to use a fixed, compatible release.
  * Added safeguards to prevent unsupported upgrades.
  * No direct user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->