### PR TITLE
fix(db): use Cosmos-compatible deduction indexes

### DIFF
--- a/database/deductionCollection.js
+++ b/database/deductionCollection.js
@@ -4,10 +4,8 @@ const deductionCollection = client.db().collection("deduction");
 deductionCollection.createIndex({ user: 1 });
 deductionCollection.createIndex({ timestamp: 1 });
 deductionCollection.createIndex({ refund: 1 });
-deductionCollection.createIndex({
-  source: 1,
-  status: 1,
-  "reviewNotification.nextAttemptAt": 1,
-});
+deductionCollection.createIndex({ source: 1 });
+deductionCollection.createIndex({ status: 1 });
+deductionCollection.createIndex({ "reviewNotification.nextAttemptAt": 1 });
 
 module.exports = deductionCollection;

--- a/test/integration/service/deduction.js
+++ b/test/integration/service/deduction.js
@@ -38,6 +38,27 @@ describe("integration: service/deduction", function () {
     sinon.restore();
   });
 
+  describe("indexes", () => {
+    it("uses Cosmos-compatible single-field indexes for Stadium review filters", async () => {
+      const indexKeys = (await deductionCollection.indexes()).map(
+        (index) => index.key,
+      );
+
+      expect(indexKeys).to.deep.include({ source: 1 });
+      expect(indexKeys).to.deep.include({ status: 1 });
+      expect(indexKeys).to.deep.include({
+        "reviewNotification.nextAttemptAt": 1,
+      });
+      expect(
+        indexKeys.some(
+          (key) =>
+            Object.hasOwn(key, "reviewNotification.nextAttemptAt") &&
+            Object.keys(key).length > 1,
+        ),
+      ).to.equal(false);
+    });
+  });
+
   describe("isBalanceSufficient", () => {
     it("should return true when the user's balance is at least the deduction value", async () => {
       await recognitionCollection.insertMany([


### PR DESCRIPTION
## Summary

- replace the unsupported compound nested deduction index with three single-field indexes
- add an integration regression test for the Cosmos-compatible index shape

## Why

After the MongoDB driver 7.5.0 pin deployed, nonprod reached Cosmos successfully but exited during startup with error 115: `Unique and compound indexes do not support nested paths.` The failing index combined `source`, `status`, and `reviewNotification.nextAttemptAt`.

Single-field indexes preserve filtering support without requiring the `EnableUniqueCompoundNestedDocs` Cosmos capability or any infrastructure replacement.

## Validation

- clean install under Node.js 24
- `npm test` — 329 unit tests and 31 integration tests pass; coverage checks pass
- `npm run lint`

No service behavior, schema, or infrastructure configuration changes.